### PR TITLE
feat: appointment scheduling + ticketing on a shared booking kernel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,14 @@ SESSION_KEY=
 ## PostgreSQL connection string (required)
 DATABASE_URL=postgres://clair:clair@localhost:5432/clair?sslmode=disable
 
+# Booking configuration
+## Shared secret the payment provider signs its webhook deliveries with
+## (HMAC-SHA256 over the raw body, sent as X-Payment-Signature). The booking
+## payment webhook is the only route that turns a hold into a paid appointment or
+## ticket, so it refuses every delivery while this is unset rather than falling
+## back to a guessable default.
+BOOKING_PAYMENT_WEBHOOK_SECRET=
+
 # ValKey configuration
 VALKEY_PORT=6379
 VALKEY_HOST=localhost # 'valkey' if using docker compose

--- a/internal/appointments/availability.go
+++ b/internal/appointments/availability.go
@@ -1,0 +1,103 @@
+// Package appointments is the appointments domain: DST-correct availability
+// computation and the (free) office-hours booking flow, on top of the booking
+// reservation kernel. It never imports net/http.
+package appointments
+
+import (
+	"time"
+
+	"github.com/erancihan/clair/internal/database/models"
+)
+
+// OpenSlot is a bookable time offered by a schedule, in UTC.
+type OpenSlot struct {
+	StartAt   time.Time `json:"start_at"`
+	EndAt     time.Time `json:"end_at"`
+	Remaining int       `json:"remaining"` // capacity - already booked
+}
+
+// ComputeAvailability returns bookable slots whose start is in [from, to).
+//
+// All wall-clock math happens in the schedule's timezone, then converts to UTC
+// — this is what makes it DST-correct: a "09:00 Monday" rule stays 09:00 local
+// across a DST boundary. Non-existent local times (spring-forward gap) are
+// skipped. `booked` maps a slot's UTC start to its current booked count.
+func ComputeAvailability(
+	sched *models.BookingSchedule,
+	rules []models.BookingAvailabilityRule,
+	exceptions []models.BookingAvailabilityException,
+	booked map[time.Time]int,
+	from, to, now time.Time,
+) ([]OpenSlot, error) {
+	loc, err := time.LoadLocation(sched.Timezone)
+	if err != nil {
+		return nil, err
+	}
+
+	exByDate := map[string][]models.BookingAvailabilityException{}
+	for _, e := range exceptions {
+		exByDate[e.Date] = append(exByDate[e.Date], e)
+	}
+
+	earliest := now.Add(time.Duration(sched.LeadTimeMin) * time.Minute)
+	latest := now.AddDate(0, 0, sched.WindowDays)
+	dur := time.Duration(sched.SlotDurationMin) * time.Minute
+
+	var out []OpenSlot
+
+	// Walk day by day in local time so weekday and DST are correct.
+	start := from.In(loc)
+	day := time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, loc)
+	for day.Before(to) {
+		dateKey := day.Format("2006-01-02")
+		wd := int(day.Weekday())
+
+		for _, rule := range rules {
+			if rule.Weekday != wd {
+				continue
+			}
+			for m := rule.StartMin; m+sched.SlotDurationMin <= rule.EndMin; m += sched.SlotDurationMin {
+				local := time.Date(day.Year(), day.Month(), day.Day(), 0, m, 0, 0, loc)
+				// Skip a wall time that does not exist on this date (DST gap):
+				// time.Date normalizes it forward, changing the minute-of-day.
+				if local.Hour()*60+local.Minute() != m {
+					continue
+				}
+
+				startUTC := local.UTC()
+				endUTC := startUTC.Add(dur)
+
+				if startUTC.Before(from) || !startUTC.Before(to) {
+					continue
+				}
+				if startUTC.Before(earliest) || startUTC.After(latest) {
+					continue
+				}
+				if blockedByException(exByDate[dateKey], m, m+sched.SlotDurationMin) {
+					continue
+				}
+
+				remaining := sched.Capacity - booked[startUTC]
+				if remaining > 0 {
+					out = append(out, OpenSlot{StartAt: startUTC, EndAt: endUTC, Remaining: remaining})
+				}
+			}
+		}
+		day = day.AddDate(0, 0, 1)
+	}
+	return out, nil
+}
+
+// blockedByException reports whether [slotStart, slotEnd) (minutes-of-day) is
+// blocked by any exception for that date.
+func blockedByException(exs []models.BookingAvailabilityException, slotStart, slotEnd int) bool {
+	for _, e := range exs {
+		if e.StartMin == nil || e.EndMin == nil { // whole day
+			return true
+		}
+		if slotStart < *e.EndMin && slotEnd > *e.StartMin { // overlap
+			return true
+		}
+	}
+	return false
+}

--- a/internal/appointments/availability_test.go
+++ b/internal/appointments/availability_test.go
@@ -1,0 +1,174 @@
+package appointments_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/erancihan/clair/internal/appointments"
+	"github.com/erancihan/clair/internal/database/models"
+)
+
+func iptr(v int) *int { return &v }
+
+func mustUTC(t *testing.T, s string) time.Time {
+	t.Helper()
+	ts, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return ts
+}
+
+// A schedule with 30-minute slots and a Mon 09:00–12:00 rule, in UTC.
+func mondaySchedule() (*models.BookingSchedule, []models.BookingAvailabilityRule) {
+	sched := &models.BookingSchedule{
+		Timezone: "UTC", SlotDurationMin: 30, Capacity: 1, WindowDays: 365,
+	}
+	rules := []models.BookingAvailabilityRule{
+		{Weekday: int(time.Monday), StartMin: 9 * 60, EndMin: 12 * 60},
+	}
+	return sched, rules
+}
+
+func TestComputeAvailability_Basic(t *testing.T) {
+	sched, rules := mondaySchedule()
+	past := mustUTC(t, "2026-01-01T00:00:00Z")
+	from := mustUTC(t, "2026-03-02T00:00:00Z") // Monday
+	to := mustUTC(t, "2026-03-03T00:00:00Z")
+
+	slots, err := appointments.ComputeAvailability(sched, rules, nil, nil, from, to, past)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(slots) != 6 {
+		t.Fatalf("want 6 slots (09:00–11:30), got %d", len(slots))
+	}
+	if !slots[0].StartAt.Equal(mustUTC(t, "2026-03-02T09:00:00Z")) {
+		t.Fatalf("first slot = %s, want 09:00Z", slots[0].StartAt)
+	}
+	if !slots[5].StartAt.Equal(mustUTC(t, "2026-03-02T11:30:00Z")) {
+		t.Fatalf("last slot = %s, want 11:30Z", slots[5].StartAt)
+	}
+}
+
+func TestComputeAvailability_WholeDayException(t *testing.T) {
+	sched, rules := mondaySchedule()
+	past := mustUTC(t, "2026-01-01T00:00:00Z")
+	from := mustUTC(t, "2026-03-02T00:00:00Z")
+	to := mustUTC(t, "2026-03-03T00:00:00Z")
+	exs := []models.BookingAvailabilityException{{Date: "2026-03-02"}} // nil min => whole day
+
+	slots, err := appointments.ComputeAvailability(sched, rules, exs, nil, from, to, past)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(slots) != 0 {
+		t.Fatalf("whole-day block should yield 0 slots, got %d", len(slots))
+	}
+}
+
+func TestComputeAvailability_PartialException(t *testing.T) {
+	sched, rules := mondaySchedule()
+	past := mustUTC(t, "2026-01-01T00:00:00Z")
+	from := mustUTC(t, "2026-03-02T00:00:00Z")
+	to := mustUTC(t, "2026-03-03T00:00:00Z")
+	// Block 09:00–10:00 → removes the 09:00 and 09:30 slots, keeps 10:00–11:30.
+	exs := []models.BookingAvailabilityException{{Date: "2026-03-02", StartMin: iptr(9 * 60), EndMin: iptr(10 * 60)}}
+
+	slots, err := appointments.ComputeAvailability(sched, rules, exs, nil, from, to, past)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(slots) != 4 {
+		t.Fatalf("want 4 slots after partial block, got %d", len(slots))
+	}
+	if !slots[0].StartAt.Equal(mustUTC(t, "2026-03-02T10:00:00Z")) {
+		t.Fatalf("first slot = %s, want 10:00Z", slots[0].StartAt)
+	}
+}
+
+func TestComputeAvailability_LeadTime(t *testing.T) {
+	sched, rules := mondaySchedule()
+	from := mustUTC(t, "2026-03-02T00:00:00Z")
+	to := mustUTC(t, "2026-03-03T00:00:00Z")
+	// now is 10:15 on the day itself → only 10:30, 11:00, 11:30 remain bookable.
+	now := mustUTC(t, "2026-03-02T10:15:00Z")
+
+	slots, err := appointments.ComputeAvailability(sched, rules, nil, nil, from, to, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(slots) != 3 {
+		t.Fatalf("want 3 slots after lead-time cut, got %d", len(slots))
+	}
+	if !slots[0].StartAt.Equal(mustUTC(t, "2026-03-02T10:30:00Z")) {
+		t.Fatalf("first bookable = %s, want 10:30Z", slots[0].StartAt)
+	}
+}
+
+func TestComputeAvailability_WindowClamp(t *testing.T) {
+	sched, rules := mondaySchedule()
+	sched.WindowDays = 0 // nothing bookable beyond "now"
+	now := mustUTC(t, "2026-03-01T00:00:00Z")
+	from := mustUTC(t, "2026-03-02T00:00:00Z")
+	to := mustUTC(t, "2026-03-03T00:00:00Z")
+
+	slots, err := appointments.ComputeAvailability(sched, rules, nil, nil, from, to, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(slots) != 0 {
+		t.Fatalf("window=0 should yield 0 future slots, got %d", len(slots))
+	}
+}
+
+func TestComputeAvailability_FullyBookedExcluded(t *testing.T) {
+	sched, rules := mondaySchedule()
+	past := mustUTC(t, "2026-01-01T00:00:00Z")
+	from := mustUTC(t, "2026-03-02T00:00:00Z")
+	to := mustUTC(t, "2026-03-03T00:00:00Z")
+	booked := map[time.Time]int{
+		mustUTC(t, "2026-03-02T09:00:00Z"): 1, // capacity 1 → this slot is full
+	}
+
+	slots, err := appointments.ComputeAvailability(sched, rules, nil, booked, from, to, past)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(slots) != 5 {
+		t.Fatalf("want 5 slots (09:00 fully booked), got %d", len(slots))
+	}
+	if !slots[0].StartAt.Equal(mustUTC(t, "2026-03-02T09:30:00Z")) {
+		t.Fatalf("first slot = %s, want 09:30Z (09:00 taken)", slots[0].StartAt)
+	}
+}
+
+// The load-bearing correctness case: a DST spring-forward day must skip the
+// non-existent local hour and keep the right UTC offsets on either side.
+func TestComputeAvailability_DSTSpringForward(t *testing.T) {
+	sched := &models.BookingSchedule{
+		Timezone: "America/New_York", SlotDurationMin: 60, Capacity: 1, WindowDays: 365,
+	}
+	// US DST 2026 begins Sun Mar 8 at 02:00 local (→ 03:00). Rule 01:00–04:00.
+	rules := []models.BookingAvailabilityRule{
+		{Weekday: int(time.Sunday), StartMin: 1 * 60, EndMin: 4 * 60},
+	}
+	past := mustUTC(t, "2026-01-01T00:00:00Z")
+	from := mustUTC(t, "2026-03-08T00:00:00Z")
+	to := mustUTC(t, "2026-03-09T12:00:00Z")
+
+	slots, err := appointments.ComputeAvailability(sched, rules, nil, nil, from, to, past)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(slots) != 2 {
+		t.Fatalf("spring-forward day: want 2 slots (01:00 EST, 03:00 EDT; 02:00 skipped), got %d: %v", len(slots), slots)
+	}
+	// 01:00 EST = 06:00Z, 03:00 EDT = 07:00Z.
+	if !slots[0].StartAt.Equal(mustUTC(t, "2026-03-08T06:00:00Z")) {
+		t.Fatalf("slot[0] = %s, want 06:00Z", slots[0].StartAt)
+	}
+	if !slots[1].StartAt.Equal(mustUTC(t, "2026-03-08T07:00:00Z")) {
+		t.Fatalf("slot[1] = %s, want 07:00Z", slots[1].StartAt)
+	}
+}

--- a/internal/appointments/book.go
+++ b/internal/appointments/book.go
@@ -1,0 +1,195 @@
+package appointments
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"time"
+
+	"github.com/erancihan/clair/internal/booking"
+	"github.com/erancihan/clair/internal/database/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+var (
+	// ErrNotOpen means the requested time is not a slot this schedule offers.
+	ErrNotOpen = errors.New("appointments: requested time is not an open slot")
+	// ErrPast means the requested time is in the past (or within lead time).
+	ErrPast = errors.New("appointments: cannot book a slot in the past")
+)
+
+// BookInput is a request to reserve a single seat in a schedule's slot.
+type BookInput struct {
+	Schedule   *models.BookingSchedule
+	StartAt    time.Time
+	UserID     *uint
+	GuestName  string
+	GuestEmail string
+}
+
+// Book reserves one seat in the slot at StartAt, using the free (no-hold,
+// no-payment) flow: validate the time is offered, lazily materialize the slot +
+// its inventory, then atomically increment the counter. Returns ErrNotOpen /
+// ErrPast / booking.ErrSoldOut on the respective failures.
+func Book(db *gorm.DB, in BookInput, now time.Time) (*models.BookingAppointment, error) {
+	startUTC := in.StartAt.UTC()
+	if !startUTC.After(now) {
+		return nil, ErrPast
+	}
+	if err := validateOpen(db, in.Schedule, startUTC, now); err != nil {
+		return nil, err
+	}
+
+	var appt *models.BookingAppointment
+	err := db.Transaction(func(tx *gorm.DB) error {
+		slot, err := ensureSlot(tx, in.Schedule, startUTC)
+		if err != nil {
+			return err
+		}
+		inv, err := booking.EnsureInventory(tx, booking.SlotOwner(slot.ID), slot.Capacity)
+		if err != nil {
+			return err
+		}
+		if err := booking.BookDirect(tx, inv.ID, 1); err != nil {
+			return err
+		}
+		a := &models.BookingAppointment{
+			ScheduleID:  in.Schedule.ID,
+			SlotID:      slot.ID,
+			UserID:      in.UserID,
+			GuestName:   in.GuestName,
+			GuestEmail:  in.GuestEmail,
+			StartAt:     startUTC,
+			EndAt:       slot.EndAt,
+			Status:      "confirmed",
+			CancelToken: newToken(),
+		}
+		if err := tx.Create(a).Error; err != nil {
+			return err
+		}
+		appt = a
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return appt, nil
+}
+
+// CancelByToken cancels a confirmed appointment and frees its slot. Idempotent:
+// an unknown or already-cancelled token is a no-op.
+func CancelByToken(db *gorm.DB, cancelToken string) error {
+	return db.Transaction(func(tx *gorm.DB) error {
+		var a models.BookingAppointment
+		err := tx.Where("cancel_token = ? AND status = ?", cancelToken, "confirmed").First(&a).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		inv, err := booking.InventoryForSlot(tx, a.SlotID)
+		if err != nil {
+			return err
+		}
+		if err := booking.Cancel(tx, inv.ID, 1, time.Now()); err != nil {
+			return err
+		}
+
+		// If this appointment came from a paid order, refund it (mock refund) and
+		// mark the order/item refunded. Free appointments have no order item.
+		var item models.BookingOrderItem
+		if err := tx.Where("fulfilled_id = ? AND status = ?", a.ID, "fulfilled").Limit(1).Find(&item).Error; err != nil {
+			return err
+		}
+		if item.ID != 0 {
+			if err := tx.Model(&models.BookingOrderItem{}).Where("id = ?", item.ID).Update("status", "refunded").Error; err != nil {
+				return err
+			}
+			if err := tx.Model(&models.BookingOrder{}).Where("id = ?", item.OrderID).Update("status", "refunded").Error; err != nil {
+				return err
+			}
+			if err := tx.Create(&models.BookingPayment{
+				OrderID: item.OrderID, Provider: "mock", Kind: "refund", Status: "succeeded",
+				AmountCents: item.PriceCents, IdempotencyKey: "refund-" + a.CancelToken,
+			}).Error; err != nil {
+				return err
+			}
+		}
+
+		return tx.Model(&a).Update("status", "cancelled").Error
+	})
+}
+
+// ensureSlot upserts the concrete slot row for (schedule, startAt) and returns
+// the canonical row.
+func ensureSlot(tx *gorm.DB, sched *models.BookingSchedule, startUTC time.Time) (*models.BookingSlot, error) {
+	slot := models.BookingSlot{
+		ScheduleID: sched.ID,
+		StartAt:    startUTC,
+		EndAt:      startUTC.Add(time.Duration(sched.SlotDurationMin) * time.Minute),
+		Capacity:   sched.Capacity,
+	}
+	if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&slot).Error; err != nil {
+		return nil, err
+	}
+	var out models.BookingSlot
+	if err := tx.Where("schedule_id = ? AND start_at = ?", sched.ID, startUTC).First(&out).Error; err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// validateOpen checks the requested UTC instant aligns to a rule-derived slot,
+// is inside lead-time/window, and is not blocked by an exception. Capacity is
+// NOT checked here — the atomic guard in Book handles that race-free.
+func validateOpen(db *gorm.DB, sched *models.BookingSchedule, startUTC, now time.Time) error {
+	loc, err := time.LoadLocation(sched.Timezone)
+	if err != nil {
+		return err
+	}
+	if startUTC.Before(now.Add(time.Duration(sched.LeadTimeMin) * time.Minute)) {
+		return ErrNotOpen
+	}
+	if startUTC.After(now.AddDate(0, 0, sched.WindowDays)) {
+		return ErrNotOpen
+	}
+
+	local := startUTC.In(loc)
+	minute := local.Hour()*60 + local.Minute()
+	wd := int(local.Weekday())
+
+	var rules []models.BookingAvailabilityRule
+	if err := db.Where("schedule_id = ? AND weekday = ?", sched.ID, wd).Find(&rules).Error; err != nil {
+		return err
+	}
+	aligned := false
+	for _, r := range rules {
+		if minute < r.StartMin || minute+sched.SlotDurationMin > r.EndMin {
+			continue
+		}
+		if (minute-r.StartMin)%sched.SlotDurationMin == 0 {
+			aligned = true
+			break
+		}
+	}
+	if !aligned {
+		return ErrNotOpen
+	}
+
+	var exs []models.BookingAvailabilityException
+	if err := db.Where("schedule_id = ? AND date = ?", sched.ID, local.Format("2006-01-02")).Find(&exs).Error; err != nil {
+		return err
+	}
+	if blockedByException(exs, minute, minute+sched.SlotDurationMin) {
+		return ErrNotOpen
+	}
+	return nil
+}
+
+func newToken() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/internal/appointments/book_test.go
+++ b/internal/appointments/book_test.go
@@ -1,0 +1,122 @@
+package appointments_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/erancihan/clair/internal/appointments"
+	"github.com/erancihan/clair/internal/booking"
+	"github.com/erancihan/clair/internal/database"
+	"github.com/erancihan/clair/internal/database/models"
+	"github.com/erancihan/clair/internal/testsupport"
+	"gorm.io/gorm"
+)
+
+// bookDB builds the application's full schema, so both the free flow and the
+// cancel-refund path (which reads booking_order_items) have their tables.
+func bookDB(t *testing.T) *gorm.DB {
+	db := testsupport.PostgresDB(t, database.MigrationModels()...)
+	return db
+}
+
+// seedSchedule creates a Mon 09:00–12:00, 30-min, capacity-1 UTC schedule.
+func seedSchedule(t *testing.T, db *gorm.DB) *models.BookingSchedule {
+	t.Helper()
+	sched := &models.BookingSchedule{
+		OwnerID: 1, Slug: "office-hours", Name: "Office Hours",
+		Timezone: "UTC", SlotDurationMin: 30, Capacity: 1, WindowDays: 365,
+	}
+	if err := db.Create(sched).Error; err != nil {
+		t.Fatalf("seed schedule: %v", err)
+	}
+	if err := db.Create(&models.BookingAvailabilityRule{
+		ScheduleID: sched.ID, Weekday: int(time.Monday), StartMin: 9 * 60, EndMin: 12 * 60,
+	}).Error; err != nil {
+		t.Fatalf("seed rule: %v", err)
+	}
+	return sched
+}
+
+func at(t *testing.T, s string) time.Time {
+	t.Helper()
+	ts, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ts
+}
+
+func TestBook_FreeFlow_HappyThenSoldOutThenCancel(t *testing.T) {
+	db := bookDB(t)
+	sched := seedSchedule(t, db)
+	now := at(t, "2026-03-01T00:00:00Z")
+	start := at(t, "2026-03-02T09:00:00Z") // Monday 09:00
+
+	appt, err := appointments.Book(db, appointments.BookInput{Schedule: sched, StartAt: start, GuestName: "Ada"}, now)
+	if err != nil {
+		t.Fatalf("first book: %v", err)
+	}
+	if appt.Status != "confirmed" || appt.CancelToken == "" {
+		t.Fatalf("unexpected appt: %+v", appt)
+	}
+
+	// capacity 1 → the same slot is now sold out
+	if _, err := appointments.Book(db, appointments.BookInput{Schedule: sched, StartAt: start, GuestName: "Bob"}, now); !errors.Is(err, booking.ErrSoldOut) {
+		t.Fatalf("second book: got %v, want ErrSoldOut", err)
+	}
+
+	// cancelling frees the slot
+	if err := appointments.CancelByToken(db, appt.CancelToken); err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+	if _, err := appointments.Book(db, appointments.BookInput{Schedule: sched, StartAt: start, GuestName: "Cara"}, now); err != nil {
+		t.Fatalf("re-book after cancel: %v", err)
+	}
+}
+
+func TestBook_RejectsUnofferedTimes(t *testing.T) {
+	db := bookDB(t)
+	sched := seedSchedule(t, db)
+	now := at(t, "2026-03-01T00:00:00Z")
+
+	cases := []struct {
+		name  string
+		start time.Time
+		want  error
+	}{
+		{"misaligned to grid", at(t, "2026-03-02T09:15:00Z"), appointments.ErrNotOpen},
+		{"wrong weekday (Sunday)", at(t, "2026-03-01T09:00:00Z"), appointments.ErrNotOpen},
+		{"outside rule window", at(t, "2026-03-02T13:00:00Z"), appointments.ErrNotOpen},
+		{"in the past", at(t, "2026-02-01T09:00:00Z"), appointments.ErrPast},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := appointments.Book(db, appointments.BookInput{Schedule: sched, StartAt: tc.start}, now)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("got %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestBook_CancelByToken_Idempotent(t *testing.T) {
+	db := bookDB(t)
+	sched := seedSchedule(t, db)
+	now := at(t, "2026-03-01T00:00:00Z")
+	start := at(t, "2026-03-02T10:00:00Z")
+
+	appt, err := appointments.Book(db, appointments.BookInput{Schedule: sched, StartAt: start}, now)
+	if err != nil {
+		t.Fatalf("book: %v", err)
+	}
+	if err := appointments.CancelByToken(db, appt.CancelToken); err != nil {
+		t.Fatalf("first cancel: %v", err)
+	}
+	if err := appointments.CancelByToken(db, appt.CancelToken); err != nil {
+		t.Fatalf("second cancel should be a no-op, got: %v", err)
+	}
+	if err := appointments.CancelByToken(db, "nonexistent-token"); err != nil {
+		t.Fatalf("unknown token should be a no-op, got: %v", err)
+	}
+}

--- a/internal/appointments/checkout.go
+++ b/internal/appointments/checkout.go
@@ -1,0 +1,107 @@
+package appointments
+
+import (
+	"time"
+
+	"github.com/erancihan/clair/internal/booking"
+	"github.com/erancihan/clair/internal/database/models"
+	"gorm.io/gorm"
+)
+
+// HoldInput is a request to reserve (hold) a slot during paid checkout.
+type HoldInput struct {
+	Schedule   *models.BookingSchedule
+	StartAt    time.Time
+	OwnerRef   string // "user:<id>" | "guest:<sid>" — identifies the holder
+	UserID     *uint
+	GuestName  string
+	GuestEmail string
+}
+
+// HoldSlot reserves a slot for the schedule's HoldTTLMin and opens a pending
+// order for it (the paid visa flow). The slot is counted in `held`, so it cannot
+// be taken by anyone else while the applicant pays; if they abandon it, the
+// reaper releases it. Confirmation happens later at payment capture.
+func HoldSlot(db *gorm.DB, in HoldInput, now time.Time) (*models.BookingOrder, *models.BookingHold, error) {
+	startUTC := in.StartAt.UTC()
+	if !startUTC.After(now) {
+		return nil, nil, ErrPast
+	}
+	if err := validateOpen(db, in.Schedule, startUTC, now); err != nil {
+		return nil, nil, err
+	}
+
+	ttl := time.Duration(in.Schedule.HoldTTLMin) * time.Minute
+	var order *models.BookingOrder
+	var hold *models.BookingHold
+
+	err := booking.WithWriteRetry(func() error {
+		return db.Transaction(func(tx *gorm.DB) error {
+			slot, err := ensureSlot(tx, in.Schedule, startUTC)
+			if err != nil {
+				return err
+			}
+			inv, err := booking.EnsureInventory(tx, booking.SlotOwner(slot.ID), slot.Capacity)
+			if err != nil {
+				return err
+			}
+			h, err := booking.HoldUnitsTx(tx, inv.ID, 1, in.OwnerRef, nil, "cart", ttl, now)
+			if err != nil {
+				return err
+			}
+			o := &models.BookingOrder{
+				Domain: "appointment", OwnerRef: in.OwnerRef, UserID: in.UserID,
+				BuyerName: in.GuestName, BuyerEmail: in.GuestEmail, Status: "pending",
+				SubtotalCents: in.Schedule.PriceCents, TotalCents: in.Schedule.PriceCents,
+				Currency: in.Schedule.Currency,
+			}
+			if err := tx.Create(o).Error; err != nil {
+				return err
+			}
+			if err := tx.Model(&models.BookingHold{}).Where("id = ?", h.ID).Update("order_id", o.ID).Error; err != nil {
+				return err
+			}
+			item := &models.BookingOrderItem{
+				OrderID: o.ID, HoldToken: h.Token, InventoryID: inv.ID, Qty: 1,
+				PriceCents: in.Schedule.PriceCents, Status: "reserved",
+			}
+			if err := tx.Create(item).Error; err != nil {
+				return err
+			}
+			order, hold = o, h
+			return nil
+		})
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return order, hold, nil
+}
+
+// slotFulfiller creates the confirmed appointment when a paid order is captured.
+type slotFulfiller struct{}
+
+func (slotFulfiller) Fulfill(tx *gorm.DB, order models.BookingOrder, item models.BookingOrderItem, inv models.BookingInventory) (uint, error) {
+	if item.FulfilledID != nil {
+		return *item.FulfilledID, nil // idempotent
+	}
+	var slot models.BookingSlot
+	if err := tx.First(&slot, *inv.SlotID).Error; err != nil {
+		return 0, err
+	}
+	appt := models.BookingAppointment{
+		ScheduleID: slot.ScheduleID, SlotID: slot.ID, UserID: order.UserID,
+		GuestName: order.BuyerName, GuestEmail: order.BuyerEmail,
+		StartAt: slot.StartAt, EndAt: slot.EndAt, Status: "confirmed", CancelToken: newToken(),
+	}
+	if err := tx.Create(&appt).Error; err != nil {
+		return 0, err
+	}
+	return appt.ID, nil
+}
+
+func init() {
+	// Register the appointment fulfiller so payment capture can create the
+	// confirmed appointment for a slot-owned inventory.
+	booking.RegisterFulfiller("slot", slotFulfiller{})
+}

--- a/internal/appointments/checkout_test.go
+++ b/internal/appointments/checkout_test.go
@@ -1,0 +1,136 @@
+package appointments_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/erancihan/clair/internal/appointments"
+	"github.com/erancihan/clair/internal/booking"
+	"github.com/erancihan/clair/internal/database"
+	"github.com/erancihan/clair/internal/database/models"
+	"github.com/erancihan/clair/internal/testsupport"
+	"gorm.io/gorm"
+)
+
+func paidDB(t *testing.T) *gorm.DB {
+	db := testsupport.PostgresDB(t, database.MigrationModels()...)
+	return db
+}
+
+func seedPaidSchedule(t *testing.T, db *gorm.DB) *models.BookingSchedule {
+	t.Helper()
+	sched := &models.BookingSchedule{
+		OwnerID: 1, Slug: "visa", Name: "Visa Interview", Timezone: "UTC",
+		SlotDurationMin: 30, Capacity: 1, WindowDays: 365,
+		RequiresPayment: true, PriceCents: 5000, Currency: "USD", HoldTTLMin: 10,
+	}
+	if err := db.Create(sched).Error; err != nil {
+		t.Fatalf("seed schedule: %v", err)
+	}
+	if err := db.Create(&models.BookingAvailabilityRule{
+		ScheduleID: sched.ID, Weekday: int(time.Monday), StartMin: 9 * 60, EndMin: 12 * 60,
+	}).Error; err != nil {
+		t.Fatalf("seed rule: %v", err)
+	}
+	return sched
+}
+
+func TestPaidAppointment_HoldCaptureFulfill(t *testing.T) {
+	db := paidDB(t)
+	sched := seedPaidSchedule(t, db)
+	now := at(t, "2026-03-01T00:00:00Z")
+	start := at(t, "2026-03-02T09:00:00Z")
+
+	order, hold, err := appointments.HoldSlot(db, appointments.HoldInput{
+		Schedule: sched, StartAt: start, OwnerRef: "guest:abc", GuestName: "Ada", GuestEmail: "ada@example.com",
+	}, now)
+	if err != nil {
+		t.Fatalf("hold: %v", err)
+	}
+	if order.Status != "pending" || hold.Status != "active" {
+		t.Fatalf("unexpected order/hold: %+v %+v", order, hold)
+	}
+	var inv models.BookingInventory
+	db.First(&inv, hold.InventoryID)
+	if inv.Held != 1 || inv.Booked != 0 {
+		t.Fatalf("after hold held=%d booked=%d, want held=1 booked=0", inv.Held, inv.Booked)
+	}
+
+	// The slot is reserved during checkout: nobody else can take it.
+	if _, _, err := appointments.HoldSlot(db, appointments.HoldInput{
+		Schedule: sched, StartAt: start, OwnerRef: "guest:def",
+	}, now); !errors.Is(err, booking.ErrSoldOut) {
+		t.Fatalf("concurrent hold: got %v, want ErrSoldOut", err)
+	}
+
+	// Capture payment → appointment is created, order paid, slot committed.
+	pay := models.BookingPayment{Provider: "mock", Kind: "capture", Status: "succeeded", AmountCents: 5000, Currency: "USD", IdempotencyKey: "evt-1"}
+	if err := booking.CaptureOrder(db, order.ID, pay, now); err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	var appts []models.BookingAppointment
+	db.Where("schedule_id = ?", sched.ID).Find(&appts)
+	if len(appts) != 1 || appts[0].GuestName != "Ada" || appts[0].Status != "confirmed" {
+		t.Fatalf("expected 1 confirmed appointment for Ada, got %+v", appts)
+	}
+	var o models.BookingOrder
+	db.First(&o, order.ID)
+	if o.Status != "paid" {
+		t.Fatalf("order status=%q, want paid", o.Status)
+	}
+	var item models.BookingOrderItem
+	db.Where("order_id = ?", order.ID).First(&item)
+	if item.Status != "fulfilled" || item.FulfilledID == nil {
+		t.Fatalf("item not fulfilled: %+v", item)
+	}
+	db.First(&inv, hold.InventoryID)
+	if inv.Held != 0 || inv.Booked != 1 {
+		t.Fatalf("after capture held=%d booked=%d, want held=0 booked=1", inv.Held, inv.Booked)
+	}
+
+	// Duplicate webhook delivery is idempotent — no second appointment.
+	if err := booking.CaptureOrder(db, order.ID, pay, now); err != nil {
+		t.Fatalf("duplicate capture: %v", err)
+	}
+	db.Where("schedule_id = ?", sched.ID).Find(&appts)
+	if len(appts) != 1 {
+		t.Fatalf("duplicate capture created %d appointments, want 1", len(appts))
+	}
+}
+
+func TestPaidAppointment_ReaperFreesAbandonedHold(t *testing.T) {
+	db := paidDB(t)
+	sched := seedPaidSchedule(t, db)
+	now := at(t, "2026-03-01T00:00:00Z")
+	start := at(t, "2026-03-02T09:00:00Z")
+
+	_, hold, err := appointments.HoldSlot(db, appointments.HoldInput{
+		Schedule: sched, StartAt: start, OwnerRef: "guest:a",
+	}, now)
+	if err != nil {
+		t.Fatalf("hold: %v", err)
+	}
+
+	// After the TTL, the reaper releases the abandoned hold and frees the slot.
+	later := now.Add(11 * time.Minute)
+	n, err := booking.ReapExpiredHolds(db, later)
+	if err != nil {
+		t.Fatalf("reap: %v", err)
+	}
+	if n < 1 {
+		t.Fatalf("reaper released %d holds, want >= 1", n)
+	}
+	var inv models.BookingInventory
+	db.First(&inv, hold.InventoryID)
+	if inv.Held != 0 {
+		t.Fatalf("after reap held=%d, want 0", inv.Held)
+	}
+
+	// The freed slot can now be held by someone else.
+	if _, _, err := appointments.HoldSlot(db, appointments.HoldInput{
+		Schedule: sched, StartAt: start, OwnerRef: "guest:c",
+	}, later); err != nil {
+		t.Fatalf("hold after reap: %v", err)
+	}
+}

--- a/internal/appointments/tzdata.go
+++ b/internal/appointments/tzdata.go
@@ -1,0 +1,6 @@
+package appointments
+
+// Embed the IANA timezone database so time.LoadLocation works regardless of
+// whether the host/container ships zoneinfo. Scheduling correctness depends on
+// timezone data being present, so we never want to rely on the environment.
+import _ "time/tzdata"

--- a/internal/booking/fulfill.go
+++ b/internal/booking/fulfill.go
@@ -1,0 +1,35 @@
+package booking
+
+import (
+	"github.com/erancihan/clair/internal/database/models"
+	"gorm.io/gorm"
+)
+
+// Fulfiller creates the domain object for a captured order item. It runs inside
+// the capture transaction, after the hold is committed, and must be idempotent
+// (return the existing id if item.FulfilledID is already set).
+type Fulfiller interface {
+	Fulfill(tx *gorm.DB, order models.BookingOrder, item models.BookingOrderItem, inv models.BookingInventory) (uint, error)
+}
+
+var fulfillers = map[string]Fulfiller{} // key: owner kind "slot"|"seat"|"tier"
+
+// RegisterFulfiller registers the fulfiller for an inventory owner kind. Domains
+// call this at init; registration is explicit, not auto-discovered.
+func RegisterFulfiller(kind string, f Fulfiller) { fulfillers[kind] = f }
+
+// FulfillerFor returns the fulfiller for an owner kind.
+func FulfillerFor(kind string) (Fulfiller, bool) { f, ok := fulfillers[kind]; return f, ok }
+
+// OwnerKind reports which typed owner an inventory row belongs to.
+func OwnerKind(inv models.BookingInventory) string {
+	switch {
+	case inv.SlotID != nil:
+		return "slot"
+	case inv.SeatID != nil:
+		return "seat"
+	case inv.TierID != nil:
+		return "tier"
+	}
+	return ""
+}

--- a/internal/booking/hold.go
+++ b/internal/booking/hold.go
@@ -1,0 +1,346 @@
+package booking
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/erancihan/clair/internal/database/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// ErrHoldExpired means the hold is no longer active (expired, released, or gone).
+var ErrHoldExpired = errors.New("booking: hold expired or not active")
+
+func newToken() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// WithWriteRetry retries fn on a Postgres deadlock (40P01) or serialization
+// failure (40001). Business errors (ErrSoldOut, ErrHoldExpired) are not retried.
+func WithWriteRetry(fn func() error) error {
+	const maxAttempts = 5
+	backoff := 20 * time.Millisecond
+	for attempt := 1; ; attempt++ {
+		err := fn()
+		if err == nil || !isRetryable(err) || attempt == maxAttempts {
+			return err
+		}
+		time.Sleep(backoff)
+		backoff *= 2
+	}
+}
+
+func isRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "40001") || strings.Contains(s, "40P01") ||
+		strings.Contains(s, "deadlock detected") || strings.Contains(s, "could not serialize")
+}
+
+// HoldUnitsTx soft-reserves qty units inside a caller-provided transaction.
+//
+// Steps: (1) release this inventory's expired active holds; (2) recompute `held`
+// authoritatively from surviving active holds (self-correcting, not a racy
+// decrement); (3) guarded increment of `held`; (4) idempotent hold insert — a
+// second active hold for the same (inventory, owner) reuses the first (backed by
+// the partial unique index), undoing our increment.
+//
+// `now` is injected so tests can drive expiry deterministically.
+func HoldUnitsTx(tx *gorm.DB, invID uint, qty int, owner string, orderID *uint, purpose string, ttl time.Duration, now time.Time) (*models.BookingHold, error) {
+	// Reclaim this inventory's expired active holds and decrement `held` by exactly
+	// the reclaimed quantity, in ONE data-modifying CTE. Using RETURNING (not a
+	// snapshot-dependent SUM subquery) keeps this race-safe under READ COMMITTED:
+	// `held` is maintained incrementally (+qty hold, -qty commit/release/reclaim),
+	// and the row lock the outer UPDATE takes serialises concurrent callers.
+	if err := tx.Exec(`
+		WITH reclaimed AS (
+			UPDATE booking_holds SET status = 'released', updated_at = now()
+			WHERE inventory_id = ? AND status = 'active' AND expires_at <= ?
+			RETURNING qty
+		)
+		UPDATE booking_inventories
+		SET held = held - COALESCE((SELECT SUM(qty) FROM reclaimed), 0)
+		WHERE id = ?`, invID, now, invID).Error; err != nil {
+		return nil, err
+	}
+
+	res := tx.Model(&models.BookingInventory{}).
+		Where("id = ? AND booked + held + blocked + ? <= capacity", invID, qty).
+		UpdateColumn("held", gorm.Expr("held + ?", qty))
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	if res.RowsAffected == 0 {
+		return nil, ErrSoldOut
+	}
+
+	h := &models.BookingHold{
+		Token: newToken(), InventoryID: invID, Qty: qty, OwnerRef: owner,
+		OrderID: orderID, Purpose: purpose, ExpiresAt: now.Add(ttl), Status: "active",
+	}
+	if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(h).Error; err != nil {
+		return nil, err
+	}
+	if h.ID == 0 { // conflict → an active hold already exists for (inv, owner)
+		if err := tx.Model(&models.BookingInventory{}).
+			Where("id = ? AND held >= ?", invID, qty).
+			UpdateColumn("held", gorm.Expr("held - ?", qty)).Error; err != nil {
+			return nil, err
+		}
+		var existing models.BookingHold
+		if err := tx.Where("inventory_id = ? AND owner_ref = ? AND status = 'active'", invID, owner).
+			First(&existing).Error; err != nil {
+			return nil, err
+		}
+		return &existing, nil
+	}
+	return h, nil
+}
+
+// HoldUnits opens its own transaction (with write-retry) around HoldUnitsTx.
+func HoldUnits(db *gorm.DB, invID uint, qty int, owner string, orderID *uint, ttl time.Duration, now time.Time) (*models.BookingHold, error) {
+	var h *models.BookingHold
+	err := WithWriteRetry(func() error {
+		return db.Transaction(func(tx *gorm.DB) error {
+			var e error
+			h, e = HoldUnitsTx(tx, invID, qty, owner, orderID, "cart", ttl, now)
+			return e
+		})
+	})
+	return h, err
+}
+
+// CommitTx converts a hold to booked (held--→booked++) inside a caller txn.
+// Idempotent: an already-committed token returns success. Row-locks the hold on
+// Postgres so Commit and the reaper never disagree at the expiry boundary.
+func CommitTx(tx *gorm.DB, token string, now time.Time) (*models.BookingHold, error) {
+	q := tx
+	if tx.Dialector != nil && tx.Dialector.Name() == "postgres" {
+		q = tx.Clauses(clause.Locking{Strength: "UPDATE"})
+	}
+	var h models.BookingHold
+	err := q.Where("token = ?", token).First(&h).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrHoldExpired
+	}
+	if err != nil {
+		return nil, err
+	}
+	if h.Status == "committed" {
+		return &h, nil // idempotent replay
+	}
+	if h.Status != "active" || !now.Before(h.ExpiresAt) {
+		return nil, ErrHoldExpired
+	}
+	res := tx.Model(&models.BookingInventory{}).
+		Where("id = ? AND held >= ?", h.InventoryID, h.Qty).
+		UpdateColumns(map[string]any{
+			"held":   gorm.Expr("held - ?", h.Qty),
+			"booked": gorm.Expr("booked + ?", h.Qty),
+		})
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	if res.RowsAffected == 0 {
+		return nil, ErrHoldExpired
+	}
+	if err := tx.Model(&h).Update("status", "committed").Error; err != nil {
+		return nil, err
+	}
+	return &h, nil
+}
+
+// Commit runs CommitTx in its own transaction.
+func Commit(db *gorm.DB, token string, now time.Time) error {
+	return WithWriteRetry(func() error {
+		return db.Transaction(func(tx *gorm.DB) error {
+			_, e := CommitTx(tx, token, now)
+			return e
+		})
+	})
+}
+
+// defaultOfferTTL is how long a freed unit is reserved for a waitlisted owner.
+const defaultOfferTTL = 10 * time.Minute
+
+// ReleaseTx frees an active hold's units, then offers the freed unit(s) to the
+// waitlist head (else they return to open inventory). Idempotent no-op if the
+// hold is already gone. If the released hold was itself a waitlist offer, its
+// waitlist entry is marked expired so it is not reused.
+func ReleaseTx(tx *gorm.DB, token string, now time.Time) error {
+	var h models.BookingHold
+	err := tx.Where("token = ? AND status = 'active'", token).First(&h).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if err := tx.Model(&models.BookingInventory{}).
+		Where("id = ? AND held >= ?", h.InventoryID, h.Qty).
+		UpdateColumn("held", gorm.Expr("held - ?", h.Qty)).Error; err != nil {
+		return err
+	}
+	if err := tx.Model(&h).Update("status", "released").Error; err != nil {
+		return err
+	}
+	if h.Purpose == "waitlist_offer" {
+		if err := tx.Model(&models.BookingWaitlistEntry{}).
+			Where("offer_token = ?", token).Update("status", "expired").Error; err != nil {
+			return err
+		}
+	}
+	return offerToWaitlist(tx, h.InventoryID, h.Qty, defaultOfferTTL, now)
+}
+
+// Release runs ReleaseTx in its own transaction.
+func Release(db *gorm.DB, token string, now time.Time) error {
+	return WithWriteRetry(func() error {
+		return db.Transaction(func(tx *gorm.DB) error {
+			return ReleaseTx(tx, token, now)
+		})
+	})
+}
+
+// offerToWaitlist converts `freed` newly-available units into time-boxed offers
+// for the oldest waiting entries (FIFO via FOR UPDATE SKIP LOCKED, so concurrent
+// freers never offer the same unit twice). Units with no waiter stay open.
+func offerToWaitlist(tx *gorm.DB, invID uint, freed int, offerTTL time.Duration, now time.Time) error {
+	for i := 0; i < freed; i++ {
+		var entry models.BookingWaitlistEntry
+		res := tx.Raw(`SELECT * FROM booking_waitlist_entries
+			WHERE inventory_id = ? AND status = 'waiting'
+			ORDER BY created_at LIMIT 1 FOR UPDATE SKIP LOCKED`, invID).Scan(&entry)
+		if res.Error != nil {
+			return res.Error
+		}
+		if entry.ID == 0 {
+			return nil // no waiters → unit returns to open inventory
+		}
+		h, err := HoldUnitsTx(tx, invID, 1, entry.OwnerRef, nil, "waitlist_offer", offerTTL, now)
+		if err != nil {
+			return nil // couldn't re-hold (shouldn't happen); leave unit open
+		}
+		tok := h.Token
+		exp := h.ExpiresAt
+		if err := tx.Model(&models.BookingWaitlistEntry{}).Where("id = ?", entry.ID).
+			Updates(map[string]any{"status": "offered", "offer_token": tok, "offer_expiry": exp}).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// JoinWaitlist adds (idempotently) a waiting entry for an owner on an inventory
+// row and returns the entry plus its 1-based position.
+func JoinWaitlist(db *gorm.DB, invID uint, ownerRef string) (*models.BookingWaitlistEntry, int, error) {
+	var entry models.BookingWaitlistEntry
+	err := WithWriteRetry(func() error {
+		return db.Transaction(func(tx *gorm.DB) error {
+			e := models.BookingWaitlistEntry{InventoryID: invID, OwnerRef: ownerRef, Status: "waiting"}
+			if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&e).Error; err != nil {
+				return err
+			}
+			if e.ID == 0 { // already waiting → reuse
+				if err := tx.Where("inventory_id = ? AND owner_ref = ? AND status = 'waiting'", invID, ownerRef).First(&e).Error; err != nil {
+					return err
+				}
+			}
+			entry = e
+			return nil
+		})
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	var ahead int64
+	db.Model(&models.BookingWaitlistEntry{}).
+		Where("inventory_id = ? AND status = 'waiting' AND created_at < ?", invID, entry.CreatedAt).Count(&ahead)
+	return &entry, int(ahead) + 1, nil
+}
+
+// CaptureOrder commits every hold on an order and fulfils each item in ONE
+// transaction (so the money path is atomic), then marks the order paid.
+// Idempotent via the payment IdempotencyKey. `pay` supplies the payment record.
+func CaptureOrder(db *gorm.DB, orderID uint, pay models.BookingPayment, now time.Time) error {
+	return WithWriteRetry(func() error {
+		return db.Transaction(func(tx *gorm.DB) error {
+			pay.OrderID = orderID
+			res := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&pay)
+			if res.Error != nil {
+				return res.Error
+			}
+			if res.RowsAffected == 0 {
+				return nil // duplicate webhook delivery
+			}
+
+			var order models.BookingOrder
+			if err := tx.First(&order, orderID).Error; err != nil {
+				return err
+			}
+			if order.Status == "paid" {
+				return nil
+			}
+
+			var items []models.BookingOrderItem
+			if err := tx.Where("order_id = ?", orderID).Find(&items).Error; err != nil {
+				return err
+			}
+			for i := range items {
+				it := items[i]
+				h, err := CommitTx(tx, it.HoldToken, now)
+				if err != nil {
+					return err
+				}
+				var inv models.BookingInventory
+				if err := tx.First(&inv, h.InventoryID).Error; err != nil {
+					return err
+				}
+				f, ok := FulfillerFor(OwnerKind(inv))
+				if !ok {
+					return fmt.Errorf("booking: no fulfiller for inventory %d", inv.ID)
+				}
+				fid, err := f.Fulfill(tx, order, it, inv)
+				if err != nil {
+					return err
+				}
+				if err := tx.Model(&models.BookingOrderItem{}).Where("id = ?", it.ID).
+					Updates(map[string]any{"status": "fulfilled", "fulfilled_id": fid}).Error; err != nil {
+					return err
+				}
+			}
+			return tx.Model(&models.BookingOrder{}).
+				Where("id = ? AND status = 'pending'", orderID).
+				Update("status", "paid").Error
+		})
+	})
+}
+
+// ReapExpiredHolds releases expired active holds and expires stale pending
+// orders whose holds are all gone. Returns the number of holds released.
+func ReapExpiredHolds(db *gorm.DB, now time.Time) (int, error) {
+	var holds []models.BookingHold
+	if err := db.Where("status = 'active' AND expires_at <= ?", now).Limit(500).Find(&holds).Error; err != nil {
+		return 0, err
+	}
+	released := 0
+	for _, h := range holds {
+		if err := Release(db, h.Token, now); err == nil {
+			released++
+		}
+	}
+	db.Model(&models.BookingOrder{}).
+		Where("status = 'pending' AND updated_at <= ?", now.Add(-30*time.Minute)).
+		Where("NOT EXISTS (SELECT 1 FROM booking_holds WHERE booking_holds.order_id = booking_orders.id AND booking_holds.status = 'active')").
+		Update("status", "expired")
+	return released, nil
+}

--- a/internal/booking/hold_test.go
+++ b/internal/booking/hold_test.go
@@ -1,0 +1,185 @@
+package booking_test
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/erancihan/clair/internal/booking"
+	"github.com/erancihan/clair/internal/database"
+	"github.com/erancihan/clair/internal/database/models"
+	"github.com/erancihan/clair/internal/testsupport"
+	"gorm.io/gorm"
+)
+
+// holdDB builds the application's full schema, so the partial unique index that
+// backs hold idempotency is present and these tests exercise the real one.
+func holdDB(t *testing.T) *gorm.DB {
+	db := testsupport.PostgresDB(t, database.MigrationModels()...)
+	return db
+}
+
+func seedInv(t *testing.T, db *gorm.DB, capacity int) *models.BookingInventory {
+	t.Helper()
+	inv := models.BookingInventory{Capacity: capacity, TierID: uptr(1)}
+	if err := db.Create(&inv).Error; err != nil {
+		t.Fatalf("seed inventory: %v", err)
+	}
+	return &inv
+}
+
+func TestHoldUnits_NoOversell(t *testing.T) {
+	db := holdDB(t)
+	const cap = 3
+	inv := seedInv(t, db, cap)
+	now := time.Now()
+
+	const N = 30
+	var wg sync.WaitGroup
+	var success int64
+	for i := 0; i < N; i++ {
+		owner := fmt.Sprintf("owner-%d", i) // distinct owners → no idempotent merge
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := booking.HoldUnits(db, inv.ID, 1, owner, nil, time.Hour, now); err == nil {
+				atomic.AddInt64(&success, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if success != cap {
+		t.Fatalf("capacity=%d but %d holds succeeded", cap, success)
+	}
+	var got models.BookingInventory
+	db.First(&got, inv.ID)
+	if got.Held != cap || got.Booked != 0 {
+		t.Fatalf("held=%d booked=%d, want held=%d booked=0", got.Held, got.Booked, cap)
+	}
+}
+
+func TestHoldUnits_IdempotentSameOwner(t *testing.T) {
+	db := holdDB(t)
+	inv := seedInv(t, db, 5)
+	now := time.Now()
+
+	a, err := booking.HoldUnits(db, inv.ID, 1, "guest:x", nil, time.Hour, now)
+	if err != nil {
+		t.Fatalf("first hold: %v", err)
+	}
+	b, err := booking.HoldUnits(db, inv.ID, 1, "guest:x", nil, time.Hour, now)
+	if err != nil {
+		t.Fatalf("second hold: %v", err)
+	}
+	if a.Token != b.Token {
+		t.Fatalf("same owner got two holds: %s vs %s", a.Token, b.Token)
+	}
+	var got models.BookingInventory
+	db.First(&got, inv.ID)
+	if got.Held != 1 {
+		t.Fatalf("held=%d, want 1 (idempotent)", got.Held)
+	}
+}
+
+func TestHold_ReclaimExpired(t *testing.T) {
+	db := holdDB(t)
+	inv := seedInv(t, db, 1) // capacity 1
+	base := time.Now()
+
+	a, err := booking.HoldUnits(db, inv.ID, 1, "owner-A", nil, 1*time.Minute, base)
+	if err != nil {
+		t.Fatalf("hold A: %v", err)
+	}
+
+	// Two minutes later A has expired; B's hold should reclaim it and succeed.
+	later := base.Add(2 * time.Minute)
+	b, err := booking.HoldUnits(db, inv.ID, 1, "owner-B", nil, 1*time.Minute, later)
+	if err != nil {
+		t.Fatalf("hold B should reclaim expired A, got: %v", err)
+	}
+
+	var reloadedA models.BookingHold
+	db.Where("token = ?", a.Token).First(&reloadedA)
+	if reloadedA.Status != "released" {
+		t.Fatalf("expired hold A status=%q, want released", reloadedA.Status)
+	}
+	var got models.BookingInventory
+	db.First(&got, inv.ID)
+	if got.Held != 1 || got.Booked != 0 {
+		t.Fatalf("held=%d booked=%d, want held=1 (B) booked=0", got.Held, got.Booked)
+	}
+	if b.Status != "active" {
+		t.Fatalf("hold B status=%q, want active", b.Status)
+	}
+}
+
+func TestCommit_HeldToBooked_Idempotent(t *testing.T) {
+	db := holdDB(t)
+	inv := seedInv(t, db, 1)
+	now := time.Now()
+
+	h, err := booking.HoldUnits(db, inv.ID, 1, "owner", nil, time.Hour, now)
+	if err != nil {
+		t.Fatalf("hold: %v", err)
+	}
+	if err := booking.Commit(db, h.Token, now); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	var got models.BookingInventory
+	db.First(&got, inv.ID)
+	if got.Held != 0 || got.Booked != 1 {
+		t.Fatalf("after commit held=%d booked=%d, want held=0 booked=1", got.Held, got.Booked)
+	}
+	// idempotent replay
+	if err := booking.Commit(db, h.Token, now); err != nil {
+		t.Fatalf("double commit should be a no-op, got: %v", err)
+	}
+	db.First(&got, inv.ID)
+	if got.Booked != 1 {
+		t.Fatalf("double commit changed booked to %d", got.Booked)
+	}
+}
+
+func TestCommit_Expired(t *testing.T) {
+	db := holdDB(t)
+	inv := seedInv(t, db, 1)
+	base := time.Now()
+
+	h, err := booking.HoldUnits(db, inv.ID, 1, "owner", nil, 1*time.Minute, base)
+	if err != nil {
+		t.Fatalf("hold: %v", err)
+	}
+	if err := booking.Commit(db, h.Token, base.Add(2*time.Minute)); err != booking.ErrHoldExpired {
+		t.Fatalf("commit expired: got %v, want ErrHoldExpired", err)
+	}
+	var got models.BookingInventory
+	db.First(&got, inv.ID)
+	if got.Booked != 0 {
+		t.Fatalf("expired commit booked a unit: booked=%d", got.Booked)
+	}
+}
+
+func TestRelease_FreesHold(t *testing.T) {
+	db := holdDB(t)
+	inv := seedInv(t, db, 1)
+	now := time.Now()
+
+	h, err := booking.HoldUnits(db, inv.ID, 1, "owner", nil, time.Hour, now)
+	if err != nil {
+		t.Fatalf("hold: %v", err)
+	}
+	if err := booking.Release(db, h.Token, now); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	var got models.BookingInventory
+	db.First(&got, inv.ID)
+	if got.Held != 0 {
+		t.Fatalf("after release held=%d, want 0", got.Held)
+	}
+	if err := booking.Release(db, h.Token, now); err != nil {
+		t.Fatalf("second release should be a no-op, got: %v", err)
+	}
+}

--- a/internal/booking/kernel.go
+++ b/internal/booking/kernel.go
@@ -1,0 +1,140 @@
+// Package booking is the shared reservation kernel: it owns capacity counting
+// for every bookable thing, independent of net/http. Domain modules
+// (appointments, ticketing) compose these primitives.
+//
+// This file contains the SQLite-and-Postgres-safe primitives used by the free
+// appointment flow (EnsureInventory, BookDirect, Cancel, Block, SetCapacity).
+// Holds, orders, payments, and seat groups are Postgres-only and live in the
+// later phase described in docs/booking-system-design.md.
+package booking
+
+import (
+	"errors"
+	"time"
+
+	"github.com/erancihan/clair/internal/database/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+var (
+	// ErrSoldOut means the atomic capacity guard rejected the reservation.
+	ErrSoldOut = errors.New("booking: sold out")
+	// ErrCapacityBelow means a capacity reduction would drop below what is
+	// already committed/held/blocked.
+	ErrCapacityBelow = errors.New("booking: cannot reduce capacity below booked+held+blocked")
+)
+
+// OwnerRef identifies which typed owner a BookingInventory row belongs to.
+// Using a small typed constructor (SlotOwner/TierOwner/SeatOwner) keeps the
+// "exactly one owner" rule in one place.
+type OwnerRef struct {
+	column string
+	id     uint
+}
+
+// SlotOwner references an appointment slot.
+func SlotOwner(id uint) OwnerRef { return OwnerRef{column: "slot_id", id: id} }
+
+// TierOwner references a GA ticket tier.
+func TierOwner(id uint) OwnerRef { return OwnerRef{column: "tier_id", id: id} }
+
+// SeatOwner references a single assigned seat.
+func SeatOwner(id uint) OwnerRef { return OwnerRef{column: "seat_id", id: id} }
+
+func (o OwnerRef) apply(inv *models.BookingInventory) {
+	switch o.column {
+	case "slot_id":
+		inv.SlotID = &o.id
+	case "tier_id":
+		inv.TierID = &o.id
+	case "seat_id":
+		inv.SeatID = &o.id
+	}
+}
+
+// EnsureInventory lazily materializes the inventory row for a typed owner and
+// returns the canonical row (created-or-existing). It upserts then re-selects by
+// the unique owner column, so the returned row always carries its ID regardless
+// of whether this call created it or lost the race to a concurrent caller.
+func EnsureInventory(tx *gorm.DB, owner OwnerRef, capacity int) (*models.BookingInventory, error) {
+	inv := models.BookingInventory{Capacity: capacity}
+	owner.apply(&inv)
+
+	if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&inv).Error; err != nil {
+		return nil, err
+	}
+	var out models.BookingInventory
+	if err := tx.Where(map[string]any{owner.column: owner.id}).First(&out).Error; err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// InventoryForSlot loads the inventory row owned by a slot (used on cancel).
+func InventoryForSlot(tx *gorm.DB, slotID uint) (*models.BookingInventory, error) {
+	return InventoryByOwner(tx, SlotOwner(slotID))
+}
+
+// InventoryByOwner loads the (already-materialized) inventory row for a typed
+// owner. Use for owners created eagerly (ticket tiers, seats).
+func InventoryByOwner(tx *gorm.DB, owner OwnerRef) (*models.BookingInventory, error) {
+	var inv models.BookingInventory
+	if err := tx.Where(map[string]any{owner.column: owner.id}).First(&inv).Error; err != nil {
+		return nil, err
+	}
+	return &inv, nil
+}
+
+// BookDirect atomically reserves qty units in a single conditional UPDATE.
+// RowsAffected == 0 is the sold-out / lost-race signal. This is race-free on
+// Postgres (row lock re-evaluates the guard) and on SQLite (serialized writer).
+func BookDirect(tx *gorm.DB, invID uint, qty int) error {
+	res := tx.Model(&models.BookingInventory{}).
+		Where("id = ? AND booked + held + blocked + ? <= capacity", invID, qty).
+		UpdateColumn("booked", gorm.Expr("booked + ?", qty))
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrSoldOut
+	}
+	return nil
+}
+
+// Cancel releases qty previously-booked units, then offers the freed unit(s) to
+// the waitlist head (else they return to open inventory). Guarded so booked
+// never goes negative; a no-op if there is nothing to release.
+func Cancel(tx *gorm.DB, invID uint, qty int, now time.Time) error {
+	res := tx.Model(&models.BookingInventory{}).
+		Where("id = ? AND booked >= ?", invID, qty).
+		UpdateColumn("booked", gorm.Expr("booked - ?", qty))
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return nil
+	}
+	return offerToWaitlist(tx, invID, qty, defaultOfferTTL, now)
+}
+
+// Block removes qty sellable units without deleting the row (house/ADA/comp).
+func Block(tx *gorm.DB, invID uint, qty int) error {
+	return tx.Model(&models.BookingInventory{}).
+		Where("id = ? AND booked + held + blocked + ? <= capacity", invID, qty).
+		UpdateColumn("blocked", gorm.Expr("blocked + ?", qty)).Error
+}
+
+// SetCapacity changes capacity, refusing to drop below booked+held+blocked.
+func SetCapacity(tx *gorm.DB, invID uint, newCap int) error {
+	res := tx.Model(&models.BookingInventory{}).
+		Where("id = ? AND ? >= booked + held + blocked", invID, newCap).
+		Update("capacity", newCap)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrCapacityBelow
+	}
+	return nil
+}

--- a/internal/booking/kernel_test.go
+++ b/internal/booking/kernel_test.go
@@ -1,0 +1,126 @@
+package booking_test
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/erancihan/clair/internal/booking"
+	"github.com/erancihan/clair/internal/database/models"
+	"github.com/erancihan/clair/internal/testsupport"
+	"gorm.io/gorm"
+)
+
+func uptr(v uint) *uint { return &v }
+
+// memDB returns a Postgres-backed DB in an isolated schema. Concurrency here is
+// genuine: goroutines get separate pooled connections and contend on the row
+// lock the guard UPDATE takes — the real production behaviour.
+func memDB(t *testing.T) *gorm.DB {
+	return testsupport.PostgresDB(t, &models.BookingInventory{})
+}
+
+func TestBookDirect_NoOversell_Capacity1(t *testing.T) {
+	db := memDB(t)
+	inv := models.BookingInventory{Capacity: 1, SlotID: uptr(1)}
+	if err := db.Create(&inv).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	const N = 30
+	var wg sync.WaitGroup
+	var success int64
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := booking.BookDirect(db, inv.ID, 1); err == nil {
+				atomic.AddInt64(&success, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if success != 1 {
+		t.Fatalf("capacity=1 but %d bookings succeeded", success)
+	}
+	var got models.BookingInventory
+	db.First(&got, inv.ID)
+	if got.Booked != 1 {
+		t.Fatalf("booked=%d, want 1", got.Booked)
+	}
+}
+
+func TestBookDirect_NoOversell_CapacityN(t *testing.T) {
+	db := memDB(t)
+	const cap = 5
+	inv := models.BookingInventory{Capacity: cap, TierID: uptr(1)}
+	if err := db.Create(&inv).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	const N = 40
+	var wg sync.WaitGroup
+	var success int64
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := booking.BookDirect(db, inv.ID, 1); err == nil {
+				atomic.AddInt64(&success, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if success != cap {
+		t.Fatalf("capacity=%d but %d bookings succeeded", cap, success)
+	}
+	var got models.BookingInventory
+	db.First(&got, inv.ID)
+	if got.Booked != cap {
+		t.Fatalf("booked=%d, want %d", got.Booked, cap)
+	}
+}
+
+func TestEnsureInventory_Idempotent(t *testing.T) {
+	db := memDB(t)
+
+	a, err := booking.EnsureInventory(db, booking.SlotOwner(7), 3)
+	if err != nil {
+		t.Fatalf("first EnsureInventory: %v", err)
+	}
+	b, err := booking.EnsureInventory(db, booking.SlotOwner(7), 3)
+	if err != nil {
+		t.Fatalf("second EnsureInventory: %v", err)
+	}
+	if a.ID != b.ID {
+		t.Fatalf("EnsureInventory returned different rows: %d vs %d", a.ID, b.ID)
+	}
+	var count int64
+	db.Model(&models.BookingInventory{}).Where("slot_id = ?", 7).Count(&count)
+	if count != 1 {
+		t.Fatalf("expected exactly 1 inventory row, got %d", count)
+	}
+}
+
+func TestSetCapacity_RefusesBelowBooked(t *testing.T) {
+	db := memDB(t)
+	inv := models.BookingInventory{Capacity: 5, Booked: 3, SeatID: uptr(1)}
+	if err := db.Create(&inv).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := booking.SetCapacity(db, inv.ID, 2); err != booking.ErrCapacityBelow {
+		t.Fatalf("shrink below booked: got %v, want ErrCapacityBelow", err)
+	}
+	var got models.BookingInventory
+	db.First(&got, inv.ID)
+	if got.Capacity != 5 {
+		t.Fatalf("capacity changed to %d despite rejection", got.Capacity)
+	}
+
+	if err := booking.SetCapacity(db, inv.ID, 3); err != nil {
+		t.Fatalf("shrink to exactly booked: %v", err)
+	}
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/erancihan/clair/internal/database/models"
+	"github.com/erancihan/clair/internal/server/booking"
 	"github.com/erancihan/clair/internal/server/games"
 	"github.com/erancihan/clair/internal/utils"
 	"gorm.io/driver/postgres"
@@ -79,6 +80,7 @@ func MigrationModels() []any {
 	// ---- domains ----------------------------------------------------------
 	// One line per domain.
 	all = append(all, games.Models()...)
+	all = append(all, booking.Models()...)
 
 	return all
 }

--- a/internal/database/models/booking_appointment.go
+++ b/internal/database/models/booking_appointment.go
@@ -1,0 +1,23 @@
+package models
+
+import "time"
+
+// BookingAppointment is a single confirmed booking against a slot.
+//
+// UserID is nil for a guest booking, which is why CancelToken exists: a visitor
+// with no account still needs one unguessable handle that lets them cancel
+// without proving who they are.
+type BookingAppointment struct {
+	ID          uint      `json:"id" gorm:"primaryKey"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	ScheduleID  uint      `json:"schedule_id" gorm:"index"`
+	SlotID      uint      `json:"slot_id" gorm:"index"`
+	UserID      *uint     `json:"user_id" gorm:"index"` // nil for guest bookings
+	GuestName   string    `json:"guest_name"`
+	GuestEmail  string    `json:"guest_email" gorm:"index"`
+	StartAt     time.Time `json:"start_at" gorm:"not null"` // UTC
+	EndAt       time.Time `json:"end_at" gorm:"not null"`
+	Status      string    `json:"status" gorm:"index;not null;default:confirmed"` // confirmed|cancelled
+	CancelToken string    `json:"cancel_token" gorm:"uniqueIndex;not null"`
+}

--- a/internal/database/models/booking_availability_exception.go
+++ b/internal/database/models/booking_availability_exception.go
@@ -1,0 +1,18 @@
+package models
+
+import "time"
+
+// BookingAvailabilityException subtracts from a schedule on one specific local
+// date: a holiday, or an afternoon the host is away. It overrides the weekly
+// rules rather than replacing them.
+//
+// A nil StartMin and EndMin blocks the whole date; a pair of values blocks only
+// that part of it.
+type BookingAvailabilityException struct {
+	ID         uint `gorm:"primaryKey"`
+	CreatedAt  time.Time
+	ScheduleID uint   `gorm:"index"`
+	Date       string `gorm:"index"` // "2006-01-02" in the schedule's timezone
+	StartMin   *int   // nil, nil => the whole day is blocked
+	EndMin     *int
+}

--- a/internal/database/models/booking_availability_rule.go
+++ b/internal/database/models/booking_availability_rule.go
@@ -1,0 +1,15 @@
+package models
+
+import "time"
+
+// BookingAvailabilityRule is one recurring weekly window in its schedule's
+// timezone. Start and end are minutes from local midnight, so the rule is
+// independent of any particular date and survives daylight-saving changes.
+type BookingAvailabilityRule struct {
+	ID         uint `gorm:"primaryKey"`
+	CreatedAt  time.Time
+	ScheduleID uint `gorm:"index"`
+	Weekday    int  `gorm:"check:weekday >= 0 AND weekday <= 6"` // 0=Sunday .. 6=Saturday
+	StartMin   int  // minutes from local midnight, inclusive
+	EndMin     int  // minutes from local midnight, exclusive
+}

--- a/internal/database/models/booking_event.go
+++ b/internal/database/models/booking_event.go
@@ -1,0 +1,22 @@
+package models
+
+import "time"
+
+// BookingEvent is a single fixed-datetime event: a concert, a showtime. It is
+// the ticketing counterpart of a schedule, and the difference is the whole of
+// why both exist: a schedule generates times, an event has exactly one.
+//
+// MaxPerBuyer caps how many tickets one buyer may hold across the event, which
+// is what stops a single client from draining a tier the moment it opens.
+type BookingEvent struct {
+	ID          uint      `json:"id" gorm:"primaryKey"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	OwnerID     uint      `json:"owner_id" gorm:"index"`
+	Slug        string    `json:"slug" gorm:"uniqueIndex;not null"`
+	Name        string    `json:"name" gorm:"not null"`
+	StartAt     time.Time `json:"start_at" gorm:"not null"` // fixed showtime, UTC
+	Timezone    string    `json:"timezone" gorm:"not null;default:UTC"`
+	Status      string    `json:"status" gorm:"index;not null;default:scheduled"` // scheduled|cancelled
+	MaxPerBuyer int       `json:"max_per_buyer" gorm:"not null;default:0"`        // 0 = unlimited
+}

--- a/internal/database/models/booking_hold.go
+++ b/internal/database/models/booking_hold.go
@@ -1,0 +1,31 @@
+package models
+
+import "time"
+
+// BookingHold is an expiring soft-reservation over one inventory row, taken
+// before payment or confirmation. The authoritative expiry lives here; Valkey,
+// when it is added, is only an accelerator. A multi-item cart is several holds
+// sharing one OrderID.
+//
+// The uq_active_bhold index below backs idempotency: an owner holds a given
+// inventory row at most once. It has to be partial — restricted to active holds —
+// because released and committed holds are kept as history, and a plain unique
+// index would stop the same owner ever holding that row again.
+//
+// idx_bhold_reap serves the reaper, which sweeps for active holds that have
+// expired and is the one query in the system that runs on a timer rather than in
+// response to a request.
+type BookingHold struct {
+	ID        uint `gorm:"primaryKey"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+
+	Token       string    `json:"token" gorm:"uniqueIndex;not null"` // opaque cart handle
+	InventoryID uint      `json:"inventory_id" gorm:"index;not null;uniqueIndex:uq_active_bhold,priority:1,where:status = 'active'"`
+	OrderID     *uint     `json:"order_id" gorm:"index"` // groups multi-item carts
+	Qty         int       `json:"qty" gorm:"not null;default:1;check:qty >= 1"`
+	OwnerRef    string    `json:"-" gorm:"not null;uniqueIndex:uq_active_bhold,priority:2"` // "user:<id>" | "guest:<sid>"
+	ExpiresAt   time.Time `json:"expires_at" gorm:"index;not null;index:idx_bhold_reap,priority:2"`
+	Status      string    `json:"status" gorm:"index;not null;default:active;index:idx_bhold_reap,priority:1"` // active|committed|released
+	Purpose     string    `json:"purpose" gorm:"not null;default:cart"`                                        // cart|waitlist_offer
+}

--- a/internal/database/models/booking_inventory.go
+++ b/internal/database/models/booking_inventory.go
@@ -1,0 +1,33 @@
+package models
+
+import "time"
+
+// BookingInventory is the booking domain's single shared primitive: a countable
+// pool guarded by an atomic capacity check. Every reservable thing (an
+// appointment slot, a ticket tier, a seat) owns exactly one row, and exactly one
+// owner FK is set.
+//
+// INVARIANT: booked + held + blocked <= capacity. It is enforced by the WHERE
+// clause of every mutation in the kernel, not by a constraint, because the guard
+// has to be the same statement that does the increment.
+//
+// All booking types are prefixed Booking* so GORM derives booking_* table names
+// that stay disjoint from sibling domains (e.g. the shop's shop_* tables). See
+// docs/booking-system-design.md.
+type BookingInventory struct {
+	ID        uint `gorm:"primaryKey"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+
+	// Exactly one of these is non-null. Nullable-unique indexes let many rows
+	// share a NULL on the columns they don't use, because Postgres treats NULLs
+	// as distinct in a unique index.
+	SlotID *uint `gorm:"uniqueIndex"` // appointment slot
+	TierID *uint `gorm:"uniqueIndex"` // GA ticket tier
+	SeatID *uint `gorm:"uniqueIndex"` // one assigned seat
+
+	Capacity int `gorm:"not null;check:capacity >= 0"`
+	Booked   int `gorm:"not null;default:0;check:booked  >= 0"`
+	Held     int `gorm:"not null;default:0;check:held    >= 0"`
+	Blocked  int `gorm:"not null;default:0;check:blocked >= 0"`
+}

--- a/internal/database/models/booking_order.go
+++ b/internal/database/models/booking_order.go
@@ -1,0 +1,31 @@
+package models
+
+import "time"
+
+// BookingOrder is the money aggregate shared by every booking flow that sells:
+// the appointments paid flow and ticketing both use it unchanged. Buyer contact
+// fields are deliberately generic so a domain fulfiller can copy them onto
+// whatever it creates (an appointment, a ticket).
+//
+// OwnerRef carries the reference the authentication layer produces, so an order
+// placed by a guest can be re-pointed at an account when that visitor signs in.
+type BookingOrder struct {
+	ID        uint      `json:"id" gorm:"primaryKey"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+
+	Domain   string `json:"domain" gorm:"index;not null"` // "appointment" | "event"
+	OwnerRef string `json:"-" gorm:"index"`               // "user:<id>" | "guest:<sid>"
+	UserID   *uint  `json:"user_id" gorm:"index"`         // nil for guest
+
+	BuyerName  string `json:"buyer_name"`
+	BuyerEmail string `json:"buyer_email" gorm:"index"`
+
+	Status        string `json:"status" gorm:"index;not null;default:pending"` // pending|paid|cancelled|expired|refunded
+	SubtotalCents int64  `json:"subtotal_cents"`
+	FeeCents      int64  `json:"fee_cents"`
+	TaxCents      int64  `json:"tax_cents"`
+	DiscountCents int64  `json:"discount_cents"`
+	TotalCents    int64  `json:"total_cents"`
+	Currency      string `json:"currency"`
+}

--- a/internal/database/models/booking_order_item.go
+++ b/internal/database/models/booking_order_item.go
@@ -1,0 +1,21 @@
+package models
+
+import "time"
+
+// BookingOrderItem is domain-agnostic: it points at a kernel hold and the
+// inventory row that hold covered. The inventory row's typed FK is what tells
+// the fulfiller what was actually reserved, which is why an item carries no
+// slot, tier or seat column of its own.
+type BookingOrderItem struct {
+	ID        uint      `json:"id" gorm:"primaryKey"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+
+	OrderID     uint   `json:"order_id" gorm:"index;not null"`
+	HoldToken   string `json:"hold_token" gorm:"index"`
+	InventoryID uint   `json:"inventory_id" gorm:"index;not null"`
+	Qty         int    `json:"qty" gorm:"not null;default:1"`
+	PriceCents  int64  `json:"price_cents"`
+	Status      string `json:"status" gorm:"index;not null;default:reserved"` // reserved|fulfilled|cancelled|refunded
+	FulfilledID *uint  `json:"fulfilled_id"`                                  // id of the created domain object
+}

--- a/internal/database/models/booking_payment.go
+++ b/internal/database/models/booking_payment.go
@@ -1,0 +1,24 @@
+package models
+
+import "time"
+
+// BookingPayment records one authorization, capture or refund event. An order
+// has several rows over its life rather than a single mutable status.
+//
+// IdempotencyKey holds the payment provider's delivery id and is uniquely
+// indexed, so a re-delivered webhook collides on insert instead of capturing an
+// order twice. That unique index is the whole of the webhook's replay defence.
+type BookingPayment struct {
+	ID        uint      `json:"id" gorm:"primaryKey"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+
+	OrderID        uint   `json:"order_id" gorm:"index;not null"`
+	Provider       string `json:"provider"`
+	ProviderRef    string `json:"provider_ref" gorm:"index"`
+	Kind           string `json:"kind" gorm:"not null;default:charge"`          // authorization|capture|charge|refund
+	Status         string `json:"status" gorm:"index;not null;default:pending"` // pending|succeeded|failed
+	AmountCents    int64  `json:"amount_cents"`
+	Currency       string `json:"currency"`
+	IdempotencyKey string `json:"-" gorm:"uniqueIndex"`
+}

--- a/internal/database/models/booking_schedule.go
+++ b/internal/database/models/booking_schedule.go
@@ -1,0 +1,33 @@
+package models
+
+import "time"
+
+// BookingSchedule is an "office hours" definition owned by a host user: the
+// recurring shape from which concrete slots are derived.
+//
+// Times are stored as a timezone plus minute offsets rather than as absolute
+// instants, so a schedule keeps meaning across a daylight-saving transition:
+// "every Tuesday at 09:00 local" stays 09:00 local on both sides of the change.
+type BookingSchedule struct {
+	ID              uint      `json:"id" gorm:"primaryKey"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+	OwnerID         uint      `json:"owner_id" gorm:"index"`
+	Slug            string    `json:"slug" gorm:"uniqueIndex;not null"` // public URL id
+	Name            string    `json:"name" gorm:"not null"`
+	Description     string    `json:"description"`
+	Timezone        string    `json:"timezone" gorm:"not null"` // IANA, e.g. "Europe/Istanbul"
+	SlotDurationMin int       `json:"slot_duration_min" gorm:"not null"`
+	Capacity        int       `json:"capacity" gorm:"not null;check:capacity >= 1"` // applicants per slot
+	LeadTimeMin     int       `json:"lead_time_min" gorm:"not null;default:0"`      // min notice before a slot is bookable
+	WindowDays      int       `json:"window_days" gorm:"not null;default:30"`       // how far ahead bookings are allowed
+	Active          bool      `json:"active" gorm:"not null;default:true"`
+
+	// Payment and hold configuration. RequiresPayment=false is the free office
+	// hours flow, which books directly. RequiresPayment=true is the paid flow:
+	// the slot is held for HoldTTLMin during checkout and confirmed on capture.
+	RequiresPayment bool   `json:"requires_payment" gorm:"not null;default:false"`
+	PriceCents      int64  `json:"price_cents" gorm:"not null;default:0"`
+	Currency        string `json:"currency" gorm:"not null;default:USD"`
+	HoldTTLMin      int    `json:"hold_ttl_min" gorm:"not null;default:10"`
+}

--- a/internal/database/models/booking_seat.go
+++ b/internal/database/models/booking_seat.go
@@ -1,0 +1,25 @@
+package models
+
+import "time"
+
+// BookingSeat is a distinct assigned seat in a seated tier, owning a
+// capacity-1 kernel inventory row.
+//
+// Section, RowName and Number are stored as typed columns rather than being
+// parsed back out of Label, which is what makes "two seats together" an ordinary
+// query instead of string arithmetic.
+//
+// Kind separates seats that exist from seats that sell: house, ada, comp and
+// kill seats are all real positions in the map that ordinary checkout must not
+// hand out.
+type BookingSeat struct {
+	ID        uint      `json:"id" gorm:"primaryKey"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	TierID    uint      `json:"tier_id" gorm:"index;uniqueIndex:idx_bseat_label"`
+	Label     string    `json:"label" gorm:"uniqueIndex:idx_bseat_label;not null"` // "A-12"
+	Section   string    `json:"section" gorm:"index"`
+	RowName   string    `json:"row_name" gorm:"index"`
+	Number    int       `json:"number" gorm:"index"`
+	Kind      string    `json:"kind" gorm:"not null;default:sellable"` // sellable|house|ada|comp|kill
+}

--- a/internal/database/models/booking_slot.go
+++ b/internal/database/models/booking_slot.go
@@ -1,0 +1,19 @@
+package models
+
+import "time"
+
+// BookingSlot is a concrete bookable time, materialized from a schedule's rules
+// the first time somebody books it. Availability itself is computed, so a
+// schedule does not write a row per slot up front.
+//
+// A slot owns a kernel BookingInventory row and keeps no counter of its own:
+// there is exactly one authoritative count per reservable thing, and it lives in
+// the inventory row the capacity guard writes.
+type BookingSlot struct {
+	ID         uint `gorm:"primaryKey"`
+	CreatedAt  time.Time
+	ScheduleID uint      `gorm:"index;uniqueIndex:idx_bslot_key"`
+	StartAt    time.Time `gorm:"uniqueIndex:idx_bslot_key;not null"` // UTC
+	EndAt      time.Time `gorm:"not null"`
+	Capacity   int       `gorm:"not null"` // snapshot of the schedule's capacity at materialization
+}

--- a/internal/database/models/booking_ticket.go
+++ b/internal/database/models/booking_ticket.go
@@ -1,0 +1,22 @@
+package models
+
+import "time"
+
+// BookingTicket is the artifact a captured order item is fulfilled into: the
+// thing the buyer actually holds. It is created at capture time, never at hold
+// time, so an abandoned checkout leaves no ticket behind.
+//
+// SeatID is null for general admission, where the tier is the whole of what was
+// bought.
+type BookingTicket struct {
+	ID          uint      `json:"id" gorm:"primaryKey"`
+	CreatedAt   time.Time `json:"created_at"`
+	OrderItemID uint      `json:"order_item_id" gorm:"index;not null"`
+	EventID     uint      `json:"event_id" gorm:"index"`
+	TierID      uint      `json:"tier_id" gorm:"index"`
+	SeatID      *uint     `json:"seat_id" gorm:"index"` // null for GA
+	Code        string    `json:"code" gorm:"uniqueIndex;not null"`
+	HolderName  string    `json:"holder_name"`
+	HolderEmail string    `json:"holder_email" gorm:"index"`
+	Status      string    `json:"status" gorm:"index;not null;default:valid"` // valid|refunded|checked_in
+}

--- a/internal/database/models/booking_ticket_tier.go
+++ b/internal/database/models/booking_ticket_tier.go
@@ -1,0 +1,20 @@
+package models
+
+import "time"
+
+// BookingTicketTier is one price tier of an event.
+//
+// The two kinds differ in where the count lives. A "ga" tier owns one pooled
+// inventory row, so selling is a counter increment. A "seated" tier owns no
+// inventory at all: each of its seats owns a capacity-1 row, because a seat is
+// either taken or it is not, and pooling them would lose which one.
+type BookingTicketTier struct {
+	ID         uint      `json:"id" gorm:"primaryKey"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+	EventID    uint      `json:"event_id" gorm:"index"`
+	Name       string    `json:"name" gorm:"not null"`
+	Kind       string    `json:"kind" gorm:"not null;check:kind IN ('ga','seated')"`
+	PriceCents int64     `json:"price_cents" gorm:"not null"`
+	Currency   string    `json:"currency" gorm:"not null;default:USD"`
+}

--- a/internal/database/models/booking_waitlist_entry.go
+++ b/internal/database/models/booking_waitlist_entry.go
@@ -1,0 +1,25 @@
+package models
+
+import "time"
+
+// BookingWaitlistEntry is a FIFO waitlist position on one inventory row. When a
+// unit frees up, through a cancellation or an expired hold, it is offered to the
+// oldest waiting entry as a time-boxed waitlist_offer hold rather than being
+// returned to open inventory, so the queue is not overtaken by whoever happens
+// to be refreshing the page.
+//
+// uq_waiting_entry keeps one waiting position per owner, so refreshing the page
+// does not buy a second place in the queue. It is partial for the same reason the
+// hold index is: entries that have been offered, converted or expired stay as
+// history, and a plain unique index would bar the owner from ever queueing again.
+type BookingWaitlistEntry struct {
+	ID        uint      `json:"id" gorm:"primaryKey"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+
+	InventoryID uint       `json:"inventory_id" gorm:"index;not null;uniqueIndex:uq_waiting_entry,priority:1,where:status = 'waiting'"`
+	OwnerRef    string     `json:"-" gorm:"index;not null;uniqueIndex:uq_waiting_entry,priority:2"` // "user:<id>" | "guest:<sid>"
+	Status      string     `json:"status" gorm:"index;not null;default:waiting"`                    // waiting|offered|converted|expired
+	OfferToken  *string    `json:"offer_token" gorm:"index"`                                        // the waitlist_offer hold, when offered
+	OfferExpiry *time.Time `json:"offer_expiry"`
+}

--- a/internal/server/booking/appointments.go
+++ b/internal/server/booking/appointments.go
@@ -1,0 +1,170 @@
+package booking
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	appt "github.com/erancihan/clair/internal/appointments"
+	kernel "github.com/erancihan/clair/internal/booking"
+	"github.com/erancihan/clair/internal/database/models"
+	api_auth "github.com/erancihan/clair/internal/server/authentication"
+	server_context "github.com/erancihan/clair/internal/server/context"
+	"go.uber.org/zap"
+)
+
+type bookReq struct {
+	StartAt    time.Time `json:"start_at"`
+	GuestName  string    `json:"guest_name"`
+	GuestEmail string    `json:"guest_email"`
+}
+
+// book reserves one place in a slot of a free schedule.
+//
+// A paid schedule is refused here rather than quietly booked for nothing: the
+// two flows differ in whether a place is committed or only held, and answering
+// the wrong one would hand out free appointments.
+func book(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sched, ok := loadSchedule(ctx, r, r.PathValue("slug"))
+		if !ok || !sched.Active {
+			http.Error(w, "schedule not found", http.StatusNotFound)
+			return
+		}
+		if sched.RequiresPayment {
+			http.Error(w, "this schedule requires payment; use /hold then checkout", http.StatusBadRequest)
+			return
+		}
+
+		var body bookReq
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid request payload", http.StatusBadRequest)
+			return
+		}
+
+		in := appt.BookInput{
+			Schedule: &sched, StartAt: body.StartAt,
+			GuestName: body.GuestName, GuestEmail: body.GuestEmail,
+		}
+		// A signed-in booker gets the appointment linked to their account, so it
+		// shows up under /appointments/me. A guest gets only the cancel token.
+		if identity, ok := api_auth.CurrentUser(r.Context()); ok {
+			uid := identity.UserID
+			in.UserID = &uid
+		}
+
+		appointment, err := appt.Book(db(ctx, r), in, time.Now())
+		switch {
+		case errors.Is(err, appt.ErrPast):
+			http.Error(w, "cannot book a slot in the past", http.StatusBadRequest)
+		case errors.Is(err, appt.ErrNotOpen):
+			http.Error(w, "requested time is not an open slot", http.StatusConflict)
+		case errors.Is(err, kernel.ErrSoldOut):
+			http.Error(w, "slot is full", http.StatusConflict)
+		case err != nil:
+			ctx.Logger.Error("book appointment", zap.Error(err))
+			http.Error(w, "server error", http.StatusInternalServerError)
+		default:
+			writeJSON(w, http.StatusCreated, appointment)
+		}
+	}
+}
+
+// holdSlot reserves a slot of a paid schedule for the length of checkout and
+// opens a pending order against it.
+//
+// Nothing is confirmed here. The place is held, not booked, and becomes an
+// appointment only when the payment webhook captures the order — which is what
+// stops an abandoned checkout from occupying a slot forever.
+func holdSlot(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sched, ok := loadSchedule(ctx, r, r.PathValue("slug"))
+		if !ok || !sched.Active {
+			http.Error(w, "schedule not found", http.StatusNotFound)
+			return
+		}
+		if !sched.RequiresPayment {
+			http.Error(w, "this schedule is free; use /book", http.StatusBadRequest)
+			return
+		}
+
+		var body bookReq
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid request payload", http.StatusBadRequest)
+			return
+		}
+
+		in := appt.HoldInput{
+			Schedule: &sched, StartAt: body.StartAt,
+			OwnerRef:  api_auth.OwnerRef(w, r),
+			GuestName: body.GuestName, GuestEmail: body.GuestEmail,
+		}
+		if identity, ok := api_auth.CurrentUser(r.Context()); ok {
+			uid := identity.UserID
+			in.UserID = &uid
+		}
+
+		order, hold, err := appt.HoldSlot(db(ctx, r), in, time.Now())
+		switch {
+		case errors.Is(err, appt.ErrPast):
+			http.Error(w, "cannot hold a slot in the past", http.StatusBadRequest)
+		case errors.Is(err, appt.ErrNotOpen):
+			http.Error(w, "requested time is not an open slot", http.StatusConflict)
+		case errors.Is(err, kernel.ErrSoldOut):
+			http.Error(w, "slot is no longer available", http.StatusConflict)
+		case err != nil:
+			ctx.Logger.Error("hold slot", zap.Error(err))
+			http.Error(w, "server error", http.StatusInternalServerError)
+		default:
+			writeJSON(w, http.StatusCreated, map[string]any{
+				"order":       order,
+				"hold_token":  hold.Token,
+				"expires_at":  hold.ExpiresAt,
+				"total_cents": order.TotalCents,
+				"currency":    order.Currency,
+			})
+		}
+	}
+}
+
+// cancelByToken cancels an appointment using the opaque token issued when it was
+// booked.
+//
+// The token is the authorization: a guest booking has no account behind it, and
+// the token is the only thing that proves the caller is the person who booked.
+// It is deliberately idempotent, because the link lands in an email and gets
+// clicked more than once.
+func cancelByToken(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		token := r.URL.Query().Get("token")
+		if token == "" {
+			http.Error(w, "token is required", http.StatusBadRequest)
+			return
+		}
+
+		if err := appt.CancelByToken(db(ctx, r), token); err != nil {
+			ctx.Logger.Error("cancel appointment", zap.Error(err))
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+// myAppointments returns the appointments the authenticated caller booked.
+func myAppointments(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		identity, ok := api_auth.CurrentUser(r.Context())
+		if !ok {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		var appointments []models.BookingAppointment
+		db(ctx, r).Where("user_id = ?", identity.UserID).Order("start_at DESC").Find(&appointments)
+
+		writeJSON(w, http.StatusOK, appointments)
+	}
+}

--- a/internal/server/booking/availability.go
+++ b/internal/server/booking/availability.go
@@ -1,0 +1,81 @@
+package booking
+
+import (
+	"net/http"
+	"time"
+
+	appt "github.com/erancihan/clair/internal/appointments"
+	"github.com/erancihan/clair/internal/database/models"
+	server_context "github.com/erancihan/clair/internal/server/context"
+	"go.uber.org/zap"
+)
+
+// availability returns the open slots of a schedule over a time range.
+//
+// Slots are computed from the schedule's rules on every request rather than
+// stored: a schedule that runs weekly for a year is a handful of rules, and
+// writing a row per slot up front would make editing those rules a migration.
+// Only slots somebody has actually booked exist as rows, which is what the
+// booked counts below are read from.
+func availability(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sched, ok := loadSchedule(ctx, r, r.PathValue("slug"))
+		if !ok || !sched.Active {
+			http.Error(w, "schedule not found", http.StatusNotFound)
+			return
+		}
+
+		now := time.Now()
+
+		from := now
+		if q := r.URL.Query().Get("from"); q != "" {
+			if ts, err := time.Parse(time.RFC3339, q); err == nil {
+				from = ts
+			}
+		}
+
+		// The schedule's own booking window is the ceiling. A caller asking for a
+		// range beyond it is clamped rather than refused, but it can never widen
+		// how far ahead the schedule is bookable.
+		to := now.AddDate(0, 0, sched.WindowDays)
+		if q := r.URL.Query().Get("to"); q != "" {
+			if ts, err := time.Parse(time.RFC3339, q); err == nil && ts.Before(to) {
+				to = ts
+			}
+		}
+
+		conn := db(ctx, r)
+		var rules []models.BookingAvailabilityRule
+		var exceptions []models.BookingAvailabilityException
+		conn.Where("schedule_id = ?", sched.ID).Find(&rules)
+		conn.Where("schedule_id = ?", sched.ID).Find(&exceptions)
+
+		// Booked counts for the slots that have been materialized in this range.
+		// The join is left, not inner: a slot row exists from the moment it is
+		// first booked, but its inventory row is what carries the count.
+		type slotCount struct {
+			StartAt time.Time
+			Booked  int
+		}
+		var counts []slotCount
+		conn.Raw(`SELECT bs.start_at AS start_at, COALESCE(bi.booked, 0) AS booked
+			FROM booking_slots bs
+			LEFT JOIN booking_inventories bi ON bi.slot_id = bs.id
+			WHERE bs.schedule_id = ? AND bs.start_at >= ? AND bs.start_at < ?`,
+			sched.ID, from.UTC(), to.UTC()).Scan(&counts)
+
+		booked := make(map[time.Time]int, len(counts))
+		for _, c := range counts {
+			booked[c.StartAt.UTC()] = c.Booked
+		}
+
+		slots, err := appt.ComputeAvailability(&sched, rules, exceptions, booked, from, to, now)
+		if err != nil {
+			ctx.Logger.Error("compute availability", zap.Error(err))
+			http.Error(w, "invalid schedule timezone", http.StatusInternalServerError)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, slots)
+	}
+}

--- a/internal/server/booking/events.go
+++ b/internal/server/booking/events.go
@@ -1,0 +1,228 @@
+package booking
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	kernel "github.com/erancihan/clair/internal/booking"
+	"github.com/erancihan/clair/internal/database/models"
+	api_auth "github.com/erancihan/clair/internal/server/authentication"
+	server_context "github.com/erancihan/clair/internal/server/context"
+	"github.com/erancihan/clair/internal/ticketing"
+	"go.uber.org/zap"
+)
+
+// loadEvent fetches an event by its public slug.
+func loadEvent(ctx server_context.BackEndContext, r *http.Request, slug string) (models.BookingEvent, bool) {
+	var event models.BookingEvent
+	res := db(ctx, r).Where("slug = ?", slug).Limit(1).Find(&event)
+	return event, res.RowsAffected == 1
+}
+
+type seatReq struct {
+	Label   string `json:"label"`
+	Section string `json:"section"`
+	RowName string `json:"row_name"`
+	Number  int    `json:"number"`
+}
+
+type tierReq struct {
+	Name       string    `json:"name"`
+	Kind       string    `json:"kind"`
+	PriceCents int64     `json:"price_cents"`
+	Currency   string    `json:"currency"`
+	Capacity   int       `json:"capacity"`
+	Seats      []seatReq `json:"seats"`
+}
+
+type createEventReq struct {
+	Slug        string    `json:"slug"`
+	Name        string    `json:"name"`
+	StartAt     time.Time `json:"start_at"`
+	Timezone    string    `json:"timezone"`
+	MaxPerBuyer int       `json:"max_per_buyer"`
+	Tiers       []tierReq `json:"tiers"`
+}
+
+// createEvent creates an event with its tiers and seats, owned by the caller.
+//
+// The two tier kinds carry different requirements, and both are checked here
+// rather than left to the domain: a GA tier is a pool and needs a capacity, a
+// seated tier is a set of distinct positions and needs the seats themselves.
+// Either one missing produces a tier that exists but can never sell.
+func createEvent(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		identity, ok := api_auth.CurrentUser(r.Context())
+		if !ok {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		var req createEventReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request payload", http.StatusBadRequest)
+			return
+		}
+		if req.Slug == "" || req.Name == "" || len(req.Tiers) == 0 {
+			http.Error(w, "slug, name and at least one tier are required", http.StatusBadRequest)
+			return
+		}
+
+		in := ticketing.EventInput{
+			OwnerID: identity.UserID, Slug: req.Slug, Name: req.Name, StartAt: req.StartAt,
+			Timezone: req.Timezone, MaxPerBuyer: req.MaxPerBuyer,
+		}
+		for _, t := range req.Tiers {
+			switch {
+			case t.Kind != "ga" && t.Kind != "seated":
+				http.Error(w, "tier kind must be ga or seated", http.StatusBadRequest)
+				return
+			case t.Kind == "ga" && t.Capacity < 1:
+				http.Error(w, "ga tier requires capacity >= 1", http.StatusBadRequest)
+				return
+			case t.Kind == "seated" && len(t.Seats) == 0:
+				http.Error(w, "seated tier requires seats", http.StatusBadRequest)
+				return
+			}
+
+			tier := ticketing.TierInput{
+				Name: t.Name, Kind: t.Kind, PriceCents: t.PriceCents,
+				Currency: t.Currency, Capacity: t.Capacity,
+			}
+			for _, st := range t.Seats {
+				tier.Seats = append(tier.Seats, ticketing.SeatInput{
+					Label: st.Label, Section: st.Section, RowName: st.RowName, Number: st.Number,
+				})
+			}
+			in.Tiers = append(in.Tiers, tier)
+		}
+
+		event, err := ticketing.CreateEvent(db(ctx, r), in)
+		if err != nil {
+			ctx.Logger.Error("create event", zap.Error(err))
+			http.Error(w, "slug likely taken or database error", http.StatusConflict)
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, event)
+	}
+}
+
+// tierView is a tier plus what is left of it, which is the number a buyer
+// actually cares about and the one a tier row does not carry.
+type tierView struct {
+	models.BookingTicketTier
+	Remaining int `json:"remaining"`
+}
+
+// getEvent returns an event with its tiers and their remaining availability.
+//
+// The two tier kinds are counted differently because they are stored
+// differently: a GA tier has one pooled inventory row to subtract from, while a
+// seated tier's availability is how many of its seats are still free.
+func getEvent(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		event, ok := loadEvent(ctx, r, r.PathValue("slug"))
+		if !ok {
+			http.Error(w, "event not found", http.StatusNotFound)
+			return
+		}
+
+		conn := db(ctx, r)
+		var tiers []models.BookingTicketTier
+		conn.Where("event_id = ?", event.ID).Order("id").Find(&tiers)
+
+		views := make([]tierView, 0, len(tiers))
+		for _, t := range tiers {
+			remaining := 0
+			if t.Kind == "ga" {
+				if inv, err := kernel.InventoryByOwner(conn, kernel.TierOwner(t.ID)); err == nil {
+					remaining = inv.Capacity - inv.Booked - inv.Held - inv.Blocked
+				}
+			} else {
+				var n int64
+				conn.Raw(`SELECT count(*) FROM booking_seats s
+					JOIN booking_inventories i ON i.seat_id = s.id
+					WHERE s.tier_id = ? AND s.kind = 'sellable'
+					  AND i.booked + i.held + i.blocked < i.capacity`, t.ID).Scan(&n)
+				remaining = int(n)
+			}
+			views = append(views, tierView{BookingTicketTier: t, Remaining: remaining})
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{"event": event, "tiers": views})
+	}
+}
+
+// seatView is one seat as the seat map renders it: its position, and whether it
+// can be picked.
+type seatView struct {
+	ID      uint   `json:"id"`
+	Label   string `json:"label"`
+	Section string `json:"section"`
+	RowName string `json:"row_name"`
+	Number  int    `json:"number"`
+	State   string `json:"state"` // free|held|booked|blocked
+}
+
+// seatMap returns an event's seats, optionally narrowed to one section, each
+// with the state the map should draw it in.
+//
+// Held seats are reported as taken. The hold may well expire, but a map that
+// showed them free would invite a buyer to pick a seat that is going to be
+// refused at checkout.
+func seatMap(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		event, ok := loadEvent(ctx, r, r.PathValue("slug"))
+		if !ok {
+			http.Error(w, "event not found", http.StatusNotFound)
+			return
+		}
+
+		type row struct {
+			ID                              uint
+			Label, Section, RowName, Kind   string
+			Number                          int
+			Booked, Held, Blocked, Capacity int
+		}
+
+		query := `SELECT s.id, s.label, s.section, s.row_name, s.number, s.kind,
+				i.booked, i.held, i.blocked, i.capacity
+			FROM booking_seats s
+			JOIN booking_ticket_tiers t ON t.id = s.tier_id
+			JOIN booking_inventories i ON i.seat_id = s.id
+			WHERE t.event_id = ?`
+		args := []any{event.ID}
+		if section := r.URL.Query().Get("section"); section != "" {
+			query += " AND s.section = ?"
+			args = append(args, section)
+		}
+		query += " ORDER BY s.section, s.row_name, s.number"
+
+		var rows []row
+		db(ctx, r).Raw(query, args...).Scan(&rows)
+
+		out := make([]seatView, 0, len(rows))
+		for _, rr := range rows {
+			state := "free"
+			switch {
+			// A seat that is not sellable at all (house, ada, comp, kill) reads
+			// the same as one held back by an operator: present on the map, not
+			// available to this buyer.
+			case rr.Kind != "sellable" || rr.Blocked > 0:
+				state = "blocked"
+			case rr.Booked > 0:
+				state = "booked"
+			case rr.Held > 0:
+				state = "held"
+			}
+			out = append(out, seatView{
+				ID: rr.ID, Label: rr.Label, Section: rr.Section,
+				RowName: rr.RowName, Number: rr.Number, State: state,
+			})
+		}
+
+		writeJSON(w, http.StatusOK, out)
+	}
+}

--- a/internal/server/booking/guest.go
+++ b/internal/server/booking/guest.go
@@ -1,0 +1,85 @@
+package booking
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/erancihan/clair/internal/database/models"
+	"gorm.io/gorm"
+)
+
+// migrateGuest hands a visitor's in-progress booking work over to the account
+// they just signed into.
+//
+// Somebody who picks a seat, then signs in to pay, would otherwise lose the hold
+// they were paying for: the hold is stamped with the guest reference they had
+// when they took it, and after login every subsequent request carries their user
+// reference instead. Re-pointing the rows is what makes signing in mid-checkout
+// a continuation rather than a restart.
+//
+// Orders additionally get user_id set, so the appointment or ticket that comes
+// out of a capture is linked to the account and not only to the guest session
+// that started it.
+//
+// The whole thing is a set of ref-scoped updates and so is safe to repeat, which
+// it has to be: the guest cookie outlives the login, and the same visitor can
+// sign in from the same browser any number of times. A second run simply matches
+// no rows.
+func migrateGuest(ctx context.Context, db *gorm.DB, guestRef, userRef string) error {
+	userID, err := userIDFromRef(userRef)
+	if err != nil {
+		return err
+	}
+
+	tx := db.WithContext(ctx)
+
+	return tx.Transaction(func(tx *gorm.DB) error {
+		// Active holds first: they are the time-critical ones, since an
+		// unclaimed hold expires while the visitor is signing in.
+		if err := tx.Model(&models.BookingHold{}).
+			Where("owner_ref = ? AND status = 'active'", guestRef).
+			Update("owner_ref", userRef).Error; err != nil {
+			return fmt.Errorf("re-own holds: %w", err)
+		}
+
+		// Only orders still in flight are moved. A cancelled or expired order is
+		// history, and a paid one has already been fulfilled to whoever bought
+		// it — reassigning either would rewrite a completed record.
+		if err := tx.Model(&models.BookingOrder{}).
+			Where("owner_ref = ? AND status = 'pending'", guestRef).
+			Updates(map[string]any{"owner_ref": userRef, "user_id": userID}).Error; err != nil {
+			return fmt.Errorf("re-own orders: %w", err)
+		}
+
+		// Waiting and offered positions both move, so the queue place survives
+		// the login and an offer already extended stays claimable.
+		if err := tx.Model(&models.BookingWaitlistEntry{}).
+			Where("owner_ref = ? AND status IN ('waiting','offered')", guestRef).
+			Update("owner_ref", userRef).Error; err != nil {
+			return fmt.Errorf("re-own waitlist entries: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// userIDFromRef extracts the numeric id from a "user:<id>" owner reference.
+//
+// The format is the authentication layer's, and it is parsed rather than assumed
+// because BookingOrder stores the id as its own column: a silently wrong parse
+// would link an order to the wrong account.
+func userIDFromRef(userRef string) (uint, error) {
+	raw, ok := strings.CutPrefix(userRef, "user:")
+	if !ok {
+		return 0, fmt.Errorf("booking: unexpected user ref %q", userRef)
+	}
+
+	id, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil || id == 0 {
+		return 0, fmt.Errorf("booking: unparseable user ref %q", userRef)
+	}
+
+	return uint(id), nil
+}

--- a/internal/server/booking/http.go
+++ b/internal/server/booking/http.go
@@ -1,0 +1,39 @@
+// Package booking is the HTTP layer for the booking domain: appointments and
+// ticketing, both sitting on the shared reservation kernel in internal/booking.
+//
+// Handlers here stay thin. They decode a request, resolve who is asking, call
+// into the domain packages and encode the answer; every rule about capacity,
+// expiry and money lives below them, where it can be tested without a server.
+package booking
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	server_context "github.com/erancihan/clair/internal/server/context"
+	"gorm.io/gorm"
+)
+
+// db returns a GORM session bound to the request's context, so a client that
+// disconnects mid-request cancels the query it was waiting on.
+func db(ctx server_context.BackEndContext, r *http.Request) *gorm.DB {
+	return ctx.DBConn.Session(&gorm.Session{Context: r.Context()})
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// parseID reads a positive integer path parameter. Zero is rejected along with
+// unparseable values: it is never a real row id, and letting it through turns a
+// malformed request into a query that quietly matches nothing.
+func parseID(r *http.Request, name string) (uint, bool) {
+	v, err := strconv.ParseUint(r.PathValue(name), 10, 64)
+	if err != nil || v == 0 {
+		return 0, false
+	}
+	return uint(v), true
+}

--- a/internal/server/booking/models.go
+++ b/internal/server/booking/models.go
@@ -1,0 +1,35 @@
+package booking
+
+import "github.com/erancihan/clair/internal/database/models"
+
+// Models returns the GORM models the booking domain owns, for the migration set
+// composed in internal/database.
+//
+// The list is grouped the way the domain is layered. The reservation kernel's
+// tables come first: they are the ones every selling flow shares, and neither
+// appointments nor ticketing owns a counter of its own. The two front-end
+// domains follow, each mapping its own vocabulary onto that kernel.
+func Models() []any {
+	return []any{
+		// Reservation kernel: the counter, the holds over it, and the money.
+		&models.BookingInventory{},
+		&models.BookingHold{},
+		&models.BookingOrder{},
+		&models.BookingOrderItem{},
+		&models.BookingPayment{},
+		&models.BookingWaitlistEntry{},
+
+		// Appointments: schedules, the rules that shape them, and the bookings.
+		&models.BookingSchedule{},
+		&models.BookingAvailabilityRule{},
+		&models.BookingAvailabilityException{},
+		&models.BookingSlot{},
+		&models.BookingAppointment{},
+
+		// Ticketing: events, their tiers and seats, and the issued tickets.
+		&models.BookingEvent{},
+		&models.BookingTicketTier{},
+		&models.BookingSeat{},
+		&models.BookingTicket{},
+	}
+}

--- a/internal/server/booking/mount.go
+++ b/internal/server/booking/mount.go
@@ -1,0 +1,137 @@
+package booking
+
+import (
+	api_auth "github.com/erancihan/clair/internal/server/authentication"
+	server_context "github.com/erancihan/clair/internal/server/context"
+	"github.com/erancihan/clair/internal/utils/router"
+)
+
+// Mount registers every route the booking domain owns onto r, following the
+// convention internal/server/games/mount.go documents.
+//
+// The domain owns two path spaces because it serves two vocabularies over one
+// reservation kernel: /appointments for schedules and office hours, /events for
+// tickets and seats. They share the kernel, the orders and the payment webhook,
+// and differ only in what a reserved unit is called.
+//
+// Routes fall into four classes, and which class a route is in is the security
+// decision this file exists to make explicit:
+//
+//   - Public reads. Availability, an event, a seat map. No identity needed, and
+//     none is required, because these are the pages a link leads to.
+//
+//   - Guest-allowed writes. Booking, holding, cancelling with a token, joining a
+//     waitlist. These deliberately do NOT sit behind AuthMiddleware: making an
+//     appointment is exactly the kind of thing a first-time visitor does, and
+//     forcing an account first is the friction this system exists to remove.
+//     Ownership follows api_auth.OwnerRef, which yields the caller's account when
+//     they have one and a stable per-browser guest reference when they do not.
+//
+//   - Authenticated. Managing a schedule you own, listing what you booked. These
+//     are about a specific account's rows, so there has to be an account.
+//
+//   - Machine. The payment webhook, authenticated by a signature over its body
+//     rather than by a session. It is outside every group below, since a session
+//     and a CSRF token are precisely what a provider does not have.
+//
+// Every mutating browser route is behind api_auth.CSRF(), mounted here on the
+// domain's own groups rather than globally — login and registration precede the
+// session a token is bound to, so a global mount would break them. The token is
+// published to the browser by the page shell as <meta name="csrf-token">.
+func Mount(r *router.Router, ctx server_context.BackEndContext) {
+	// A visitor who holds a seat as a guest and then signs in to pay keeps that
+	// hold. Registering here, from the domain, is what lets the authentication
+	// layer run this without importing the booking domain.
+	api_auth.RegisterGuestMigrator("booking", migrateGuest)
+
+	mountAppointments(r, ctx)
+	mountEvents(r, ctx)
+
+	// The payment webhook is mounted at the top level, outside both domains: one
+	// order can hold appointment slots or event seats, and the provider signing
+	// the delivery has no idea which.
+	r.Group("webhooks/payments", func(hooks *router.Router) {
+		hooks.HandleFunc("POST /{provider}", paymentWebhook(ctx))
+	})
+}
+
+// mountAppointments registers the /appointments path space: the office-hours
+// vocabulary over the reservation kernel.
+func mountAppointments(r *router.Router, ctx server_context.BackEndContext) {
+	r.Group("appointments", func(appointments *router.Router) {
+		// ---- public reads ----
+		appointments.HandleFunc("GET /schedules/{slug}/availability", availability(ctx))
+
+		// ---- guest-allowed writes ----
+		appointments.Group("", func(guest *router.Router) {
+			guest.HandleFunc("POST /schedules/{slug}/book", book(ctx))
+			guest.HandleFunc("POST /schedules/{slug}/hold", holdSlot(ctx))
+
+			// The cancel token is the authorization here: a guest booking has no
+			// account behind it, and the token is the only thing proving the
+			// caller is who booked.
+			guest.HandleFunc("POST /cancel", cancelByToken(ctx))
+		}, api_auth.CSRF())
+
+		// ---- authenticated: the booker's own appointments ----
+		appointments.Group("", func(mine *router.Router) {
+			mine.HandleFunc("GET /me", myAppointments(ctx))
+		}, api_auth.AuthMiddleware(ctx))
+
+		// ---- authenticated: managing schedules you host ----
+		//
+		// CSRF sits alongside AuthMiddleware rather than instead of it. A session
+		// cookie is sent on cross-site requests too, so authentication alone does
+		// not stop another origin from posting here as the signed-in host.
+		//
+		// The group takes no prefix of its own and every route spells out
+		// "/schedules/...". Nesting a "schedules" group and registering "/" in it
+		// would produce the pattern "/appointments/schedules/", and a pattern
+		// ending in a slash matches a whole subtree: the bare collection path
+		// would answer with a 301, and any unmatched POST below it — a typo, a
+		// probe — would reach the create handler instead of a 404.
+		appointments.Group("", func(host *router.Router) {
+			host.HandleFunc("POST /schedules", createSchedule(ctx))
+			host.HandleFunc("GET /schedules", listSchedules(ctx))
+
+			host.HandleFunc("GET /schedules/{slug}", getSchedule(ctx))
+			host.HandleFunc("GET /schedules/{slug}/bookings", listBookings(ctx))
+
+			host.HandleFunc("POST /schedules/{slug}/rules", addRule(ctx))
+			host.HandleFunc("DELETE /schedules/{slug}/rules/{id}", deleteRule(ctx))
+
+			host.HandleFunc("POST /schedules/{slug}/exceptions", addException(ctx))
+			host.HandleFunc("DELETE /schedules/{slug}/exceptions/{id}", deleteException(ctx))
+		}, api_auth.AuthMiddleware(ctx), api_auth.CSRF())
+	})
+}
+
+// mountEvents registers the /events path space: the ticketing vocabulary over the
+// same kernel.
+func mountEvents(r *router.Router, ctx server_context.BackEndContext) {
+	// ---- authenticated: running an event ----
+	//
+	// Creating an event is the collection endpoint, so it is registered from the
+	// top-level router to land on "/events" exactly. Registering "/" inside the
+	// "events" group below would instead produce the subtree pattern "/events/",
+	// which answers every unmatched POST under it.
+	r.Group("", func(owner *router.Router) {
+		owner.HandleFunc("POST /events", createEvent(ctx))
+	}, api_auth.AuthMiddleware(ctx), api_auth.CSRF())
+
+	r.Group("events", func(events *router.Router) {
+		// ---- public reads ----
+		events.HandleFunc("GET /{slug}", getEvent(ctx))
+		events.HandleFunc("GET /{slug}/seats", seatMap(ctx))
+
+		// ---- guest-allowed writes ----
+		events.Group("", func(guest *router.Router) {
+			guest.HandleFunc("POST /{slug}/tiers/{tierID}/hold", holdGA(ctx))
+			guest.HandleFunc("POST /{slug}/seats/hold", holdSeats(ctx))
+
+			guest.HandleFunc("POST /{slug}/tiers/{tierID}/waitlist", joinWaitlistGA(ctx))
+			guest.HandleFunc("POST /{slug}/seats/{seatID}/waitlist", joinWaitlistSeat(ctx))
+			guest.HandleFunc("POST /{slug}/waitlist/claim", claimOffer(ctx))
+		}, api_auth.CSRF())
+	})
+}

--- a/internal/server/booking/schedules.go
+++ b/internal/server/booking/schedules.go
@@ -1,0 +1,342 @@
+package booking
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/erancihan/clair/internal/database/models"
+	api_auth "github.com/erancihan/clair/internal/server/authentication"
+	server_context "github.com/erancihan/clair/internal/server/context"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+// loadSchedule fetches a schedule by its public slug, with no ownership check.
+// It backs the routes anyone may call.
+func loadSchedule(ctx server_context.BackEndContext, r *http.Request, slug string) (models.BookingSchedule, bool) {
+	var sched models.BookingSchedule
+	res := db(ctx, r).Where("slug = ?", slug).Limit(1).Find(&sched)
+	return sched, res.RowsAffected == 1
+}
+
+// loadOwnedSchedule fetches a schedule the authenticated caller owns.
+//
+// A schedule somebody else owns reports "not found" rather than "forbidden": the
+// slug is guessable, and answering "forbidden" would confirm which slugs exist
+// to anyone willing to enumerate them.
+func loadOwnedSchedule(ctx server_context.BackEndContext, r *http.Request, slug string) (models.BookingSchedule, bool) {
+	identity, ok := api_auth.CurrentUser(r.Context())
+	if !ok {
+		return models.BookingSchedule{}, false
+	}
+
+	var sched models.BookingSchedule
+	res := db(ctx, r).Where("slug = ? AND owner_id = ?", slug, identity.UserID).Limit(1).Find(&sched)
+	return sched, res.RowsAffected == 1
+}
+
+type ruleReq struct {
+	Weekday  int `json:"weekday"`
+	StartMin int `json:"start_min"`
+	EndMin   int `json:"end_min"`
+}
+
+type createScheduleReq struct {
+	Slug            string    `json:"slug"`
+	Name            string    `json:"name"`
+	Description     string    `json:"description"`
+	Timezone        string    `json:"timezone"`
+	SlotDurationMin int       `json:"slot_duration_min"`
+	Capacity        int       `json:"capacity"`
+	LeadTimeMin     int       `json:"lead_time_min"`
+	WindowDays      int       `json:"window_days"`
+	RequiresPayment bool      `json:"requires_payment"`
+	PriceCents      int64     `json:"price_cents"`
+	Currency        string    `json:"currency"`
+	HoldTTLMin      int       `json:"hold_ttl_min"`
+	Rules           []ruleReq `json:"rules"`
+}
+
+// validRule reports whether a weekly availability window is expressible: a real
+// weekday, inside a day, and ending after it starts.
+func validRule(rl ruleReq) bool {
+	return rl.Weekday >= 0 && rl.Weekday <= 6 &&
+		rl.StartMin >= 0 && rl.EndMin <= 24*60 && rl.StartMin < rl.EndMin
+}
+
+// createSchedule creates a schedule owned by the authenticated caller, together
+// with its initial availability rules.
+//
+// The schedule and its rules are written in one transaction. A schedule that
+// committed without them would be live and permanently unbookable, since
+// availability is computed from the rules.
+func createSchedule(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		identity, ok := api_auth.CurrentUser(r.Context())
+		if !ok {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		var req createScheduleReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request payload", http.StatusBadRequest)
+			return
+		}
+		if req.Slug == "" || req.Name == "" {
+			http.Error(w, "slug and name are required", http.StatusBadRequest)
+			return
+		}
+		if req.SlotDurationMin <= 0 || req.Capacity < 1 {
+			http.Error(w, "slot_duration_min must be > 0 and capacity >= 1", http.StatusBadRequest)
+			return
+		}
+		// The timezone is what every rule's minute offsets are interpreted in, so
+		// an unloadable one makes the whole schedule uncomputable later.
+		if _, err := time.LoadLocation(req.Timezone); err != nil {
+			http.Error(w, "invalid IANA timezone", http.StatusBadRequest)
+			return
+		}
+		if req.WindowDays <= 0 {
+			req.WindowDays = 30
+		}
+		if req.RequiresPayment {
+			if req.PriceCents <= 0 {
+				http.Error(w, "price_cents must be > 0 for a paid schedule", http.StatusBadRequest)
+				return
+			}
+			if req.Currency == "" {
+				req.Currency = "USD"
+			}
+			if req.HoldTTLMin <= 0 {
+				req.HoldTTLMin = 10
+			}
+		}
+		for _, rl := range req.Rules {
+			if !validRule(rl) {
+				http.Error(w, "invalid availability rule", http.StatusBadRequest)
+				return
+			}
+		}
+
+		sched := models.BookingSchedule{
+			OwnerID: identity.UserID, Slug: req.Slug, Name: req.Name, Description: req.Description,
+			Timezone: req.Timezone, SlotDurationMin: req.SlotDurationMin, Capacity: req.Capacity,
+			LeadTimeMin: req.LeadTimeMin, WindowDays: req.WindowDays, Active: true,
+			RequiresPayment: req.RequiresPayment, PriceCents: req.PriceCents,
+			Currency: req.Currency, HoldTTLMin: req.HoldTTLMin,
+		}
+		err := db(ctx, r).Transaction(func(tx *gorm.DB) error {
+			if err := tx.Create(&sched).Error; err != nil {
+				return err
+			}
+			for _, rl := range req.Rules {
+				if err := tx.Create(&models.BookingAvailabilityRule{
+					ScheduleID: sched.ID, Weekday: rl.Weekday, StartMin: rl.StartMin, EndMin: rl.EndMin,
+				}).Error; err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			ctx.Logger.Error("create schedule", zap.Error(err))
+			http.Error(w, "slug likely taken or database error", http.StatusConflict)
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, sched)
+	}
+}
+
+// listSchedules returns the schedules the authenticated caller owns.
+func listSchedules(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		identity, ok := api_auth.CurrentUser(r.Context())
+		if !ok {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		var schedules []models.BookingSchedule
+		db(ctx, r).Where("owner_id = ?", identity.UserID).Order("created_at DESC").Find(&schedules)
+
+		writeJSON(w, http.StatusOK, schedules)
+	}
+}
+
+// getSchedule returns the owner's schedule with the rules and exceptions that
+// shape it, which together are everything needed to edit it.
+func getSchedule(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sched, ok := loadOwnedSchedule(ctx, r, r.PathValue("slug"))
+		if !ok {
+			http.Error(w, "schedule not found", http.StatusNotFound)
+			return
+		}
+
+		conn := db(ctx, r)
+		var rules []models.BookingAvailabilityRule
+		var exceptions []models.BookingAvailabilityException
+		conn.Where("schedule_id = ?", sched.ID).Order("weekday, start_min").Find(&rules)
+		conn.Where("schedule_id = ?", sched.ID).Order("date").Find(&exceptions)
+
+		writeJSON(w, http.StatusOK, map[string]any{
+			"schedule": sched, "rules": rules, "exceptions": exceptions,
+		})
+	}
+}
+
+// addRule adds a weekly availability window to the owner's schedule.
+func addRule(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sched, ok := loadOwnedSchedule(ctx, r, r.PathValue("slug"))
+		if !ok {
+			http.Error(w, "schedule not found", http.StatusNotFound)
+			return
+		}
+
+		var body ruleReq
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid request payload", http.StatusBadRequest)
+			return
+		}
+		if !validRule(body) {
+			http.Error(w, "invalid availability rule", http.StatusBadRequest)
+			return
+		}
+
+		rule := models.BookingAvailabilityRule{
+			ScheduleID: sched.ID, Weekday: body.Weekday, StartMin: body.StartMin, EndMin: body.EndMin,
+		}
+		if err := db(ctx, r).Create(&rule).Error; err != nil {
+			ctx.Logger.Error("add availability rule", zap.Error(err))
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, rule)
+	}
+}
+
+// deleteRule removes an availability rule from the owner's schedule.
+//
+// Appointments already booked against times the rule generated are untouched: a
+// materialized slot is a row of its own, and withdrawing future availability is
+// not the same as cancelling what people already hold.
+func deleteRule(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sched, ok := loadOwnedSchedule(ctx, r, r.PathValue("slug"))
+		if !ok {
+			http.Error(w, "schedule not found", http.StatusNotFound)
+			return
+		}
+		id, ok := parseID(r, "id")
+		if !ok {
+			http.Error(w, "invalid rule id", http.StatusBadRequest)
+			return
+		}
+
+		// The schedule id is part of the WHERE clause, so an id belonging to
+		// somebody else's schedule deletes nothing rather than being trusted
+		// because the caller owns some schedule.
+		res := db(ctx, r).Where("id = ? AND schedule_id = ?", id, sched.ID).
+			Delete(&models.BookingAvailabilityRule{})
+		if res.RowsAffected == 0 {
+			http.Error(w, "rule not found", http.StatusNotFound)
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+type exceptionReq struct {
+	Date     string `json:"date"` // "2006-01-02"
+	StartMin *int   `json:"start_min"`
+	EndMin   *int   `json:"end_min"`
+}
+
+// addException blocks all or part of one date on the owner's schedule.
+func addException(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sched, ok := loadOwnedSchedule(ctx, r, r.PathValue("slug"))
+		if !ok {
+			http.Error(w, "schedule not found", http.StatusNotFound)
+			return
+		}
+
+		var body exceptionReq
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid request payload", http.StatusBadRequest)
+			return
+		}
+		if _, err := time.Parse("2006-01-02", body.Date); err != nil {
+			http.Error(w, "date must be YYYY-MM-DD", http.StatusBadRequest)
+			return
+		}
+		// One bound without the other has no meaning: a whole-day block is both
+		// omitted, a partial block is both present.
+		if (body.StartMin == nil) != (body.EndMin == nil) {
+			http.Error(w, "start_min and end_min must both be set or both omitted", http.StatusBadRequest)
+			return
+		}
+		if body.StartMin != nil && (*body.StartMin < 0 || *body.EndMin > 24*60 || *body.StartMin >= *body.EndMin) {
+			http.Error(w, "invalid exception window", http.StatusBadRequest)
+			return
+		}
+
+		exception := models.BookingAvailabilityException{
+			ScheduleID: sched.ID, Date: body.Date, StartMin: body.StartMin, EndMin: body.EndMin,
+		}
+		if err := db(ctx, r).Create(&exception).Error; err != nil {
+			ctx.Logger.Error("add availability exception", zap.Error(err))
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, exception)
+	}
+}
+
+// deleteException removes a date exception from the owner's schedule.
+func deleteException(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sched, ok := loadOwnedSchedule(ctx, r, r.PathValue("slug"))
+		if !ok {
+			http.Error(w, "schedule not found", http.StatusNotFound)
+			return
+		}
+		id, ok := parseID(r, "id")
+		if !ok {
+			http.Error(w, "invalid exception id", http.StatusBadRequest)
+			return
+		}
+
+		res := db(ctx, r).Where("id = ? AND schedule_id = ?", id, sched.ID).
+			Delete(&models.BookingAvailabilityException{})
+		if res.RowsAffected == 0 {
+			http.Error(w, "exception not found", http.StatusNotFound)
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// listBookings returns the appointments booked against the owner's schedule.
+func listBookings(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sched, ok := loadOwnedSchedule(ctx, r, r.PathValue("slug"))
+		if !ok {
+			http.Error(w, "schedule not found", http.StatusNotFound)
+			return
+		}
+
+		var appointments []models.BookingAppointment
+		db(ctx, r).Where("schedule_id = ?", sched.ID).Order("start_at").Find(&appointments)
+
+		writeJSON(w, http.StatusOK, appointments)
+	}
+}

--- a/internal/server/booking/tickets.go
+++ b/internal/server/booking/tickets.go
@@ -1,0 +1,280 @@
+package booking
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	kernel "github.com/erancihan/clair/internal/booking"
+	"github.com/erancihan/clair/internal/database/models"
+	api_auth "github.com/erancihan/clair/internal/server/authentication"
+	server_context "github.com/erancihan/clair/internal/server/context"
+	"github.com/erancihan/clair/internal/ticketing"
+	"go.uber.org/zap"
+)
+
+// cartTTL is how long a ticketing hold survives without being paid for. It is
+// the trade-off between giving a buyer time to finish checkout and letting an
+// abandoned cart keep a seat out of circulation.
+const cartTTL = 10 * time.Minute
+
+// buyer builds the purchaser for a ticketing request.
+//
+// OwnerRef is what the per-buyer limit and the waitlist are counted against, and
+// it comes from the shared authentication layer so a guest's holds carry the
+// same reference their account inherits when they sign in.
+func buyer(w http.ResponseWriter, r *http.Request, name, email string) ticketing.Buyer {
+	b := ticketing.Buyer{OwnerRef: api_auth.OwnerRef(w, r), Name: name, Email: email}
+	if identity, ok := api_auth.CurrentUser(r.Context()); ok {
+		uid := identity.UserID
+		b.UserID = &uid
+	}
+	return b
+}
+
+// loadGATier fetches a GA tier belonging to an event, writing the error response
+// itself when there is none. The kind is part of the query: a seated tier sells
+// through the seat routes, and treating one as a pool would hand out tickets
+// with no seat behind them.
+func loadGATier(ctx server_context.BackEndContext, w http.ResponseWriter, r *http.Request, eventID uint) (models.BookingTicketTier, bool) {
+	tierID, ok := parseID(r, "tierID")
+	if !ok {
+		http.Error(w, "invalid tier id", http.StatusBadRequest)
+		return models.BookingTicketTier{}, false
+	}
+
+	var tier models.BookingTicketTier
+	res := db(ctx, r).Where("id = ? AND event_id = ? AND kind = 'ga'", tierID, eventID).Limit(1).Find(&tier)
+	if res.RowsAffected == 0 {
+		http.Error(w, "GA tier not found", http.StatusNotFound)
+		return models.BookingTicketTier{}, false
+	}
+
+	return tier, true
+}
+
+type holdGAReq struct {
+	Qty        int    `json:"qty"`
+	GuestName  string `json:"guest_name"`
+	GuestEmail string `json:"guest_email"`
+}
+
+// holdGA holds units of a general admission tier and opens a pending order.
+func holdGA(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		event, ok := loadEvent(ctx, r, r.PathValue("slug"))
+		if !ok || event.Status != "scheduled" {
+			http.Error(w, "event not found", http.StatusNotFound)
+			return
+		}
+		tier, ok := loadGATier(ctx, w, r, event.ID)
+		if !ok {
+			return
+		}
+
+		var body holdGAReq
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body.Qty <= 0 {
+			body.Qty = 1
+		}
+
+		order, hold, err := ticketing.HoldGA(
+			db(ctx, r), &tier, body.Qty,
+			buyer(w, r, body.GuestName, body.GuestEmail),
+			cartTTL, time.Now(), event.MaxPerBuyer,
+		)
+		switch {
+		case errors.Is(err, kernel.ErrSoldOut):
+			http.Error(w, "not enough tickets available", http.StatusConflict)
+		case errors.Is(err, ticketing.ErrPurchaseLimit):
+			http.Error(w, "per-buyer purchase limit exceeded", http.StatusConflict)
+		case err != nil:
+			ctx.Logger.Error("hold GA tickets", zap.Error(err))
+			http.Error(w, "server error", http.StatusInternalServerError)
+		default:
+			writeJSON(w, http.StatusCreated, map[string]any{
+				"order":       order,
+				"hold_token":  hold.Token,
+				"expires_at":  hold.ExpiresAt,
+				"total_cents": order.TotalCents,
+			})
+		}
+	}
+}
+
+type holdSeatsReq struct {
+	SeatIDs    []uint `json:"seat_ids"`
+	GuestName  string `json:"guest_name"`
+	GuestEmail string `json:"guest_email"`
+}
+
+// holdSeats holds a set of assigned seats, all or nothing.
+//
+// Partial success is not offered on purpose: somebody buying four seats together
+// does not want whichever two were still free.
+func holdSeats(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		event, ok := loadEvent(ctx, r, r.PathValue("slug"))
+		if !ok || event.Status != "scheduled" {
+			http.Error(w, "event not found", http.StatusNotFound)
+			return
+		}
+
+		var body holdSeatsReq
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil || len(body.SeatIDs) == 0 {
+			http.Error(w, "seat_ids required", http.StatusBadRequest)
+			return
+		}
+
+		// Every requested seat must belong to this event. Without this the seat
+		// ids are caller-supplied primary keys, and one event's checkout could
+		// reach into another's seat map.
+		var n int64
+		db(ctx, r).Raw(`SELECT count(*) FROM booking_seats s
+			JOIN booking_ticket_tiers t ON t.id = s.tier_id
+			WHERE t.event_id = ? AND s.id IN ?`, event.ID, body.SeatIDs).Scan(&n)
+		if int(n) != len(body.SeatIDs) {
+			http.Error(w, "one or more seats do not belong to this event", http.StatusBadRequest)
+			return
+		}
+
+		order, tokens, err := ticketing.HoldSeatGroup(
+			db(ctx, r), event.ID, body.SeatIDs,
+			buyer(w, r, body.GuestName, body.GuestEmail),
+			cartTTL, time.Now(), event.MaxPerBuyer,
+		)
+		switch {
+		case errors.Is(err, kernel.ErrSoldOut):
+			http.Error(w, "one or more seats are no longer available", http.StatusConflict)
+		case errors.Is(err, ticketing.ErrPurchaseLimit):
+			http.Error(w, "per-buyer purchase limit exceeded", http.StatusConflict)
+		case errors.Is(err, ticketing.ErrInvalidSeat):
+			http.Error(w, "invalid or non-sellable seat", http.StatusBadRequest)
+		case err != nil:
+			ctx.Logger.Error("hold seats", zap.Error(err))
+			http.Error(w, "server error", http.StatusInternalServerError)
+		default:
+			writeJSON(w, http.StatusCreated, map[string]any{
+				"order":       order,
+				"hold_tokens": tokens,
+				"total_cents": order.TotalCents,
+			})
+		}
+	}
+}
+
+type waitlistReq struct {
+	GuestName  string `json:"guest_name"`
+	GuestEmail string `json:"guest_email"`
+}
+
+// joinWaitlistGA puts the caller in the queue for a sold-out GA tier.
+func joinWaitlistGA(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		event, ok := loadEvent(ctx, r, r.PathValue("slug"))
+		if !ok {
+			http.Error(w, "event not found", http.StatusNotFound)
+			return
+		}
+		tier, ok := loadGATier(ctx, w, r, event.ID)
+		if !ok {
+			return
+		}
+
+		var body waitlistReq
+		_ = json.NewDecoder(r.Body).Decode(&body)
+
+		entry, position, err := ticketing.JoinWaitlistTier(
+			db(ctx, r), &tier, buyer(w, r, body.GuestName, body.GuestEmail).OwnerRef,
+		)
+		if err != nil {
+			ctx.Logger.Error("join tier waitlist", zap.Error(err))
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, map[string]any{"entry": entry, "position": position})
+	}
+}
+
+// joinWaitlistSeat puts the caller in the queue for one specific seat.
+func joinWaitlistSeat(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		event, ok := loadEvent(ctx, r, r.PathValue("slug"))
+		if !ok {
+			http.Error(w, "event not found", http.StatusNotFound)
+			return
+		}
+		seatID, ok := parseID(r, "seatID")
+		if !ok {
+			http.Error(w, "invalid seat id", http.StatusBadRequest)
+			return
+		}
+
+		var n int64
+		db(ctx, r).Raw(`SELECT count(*) FROM booking_seats s
+			JOIN booking_ticket_tiers t ON t.id = s.tier_id
+			WHERE t.event_id = ? AND s.id = ?`, event.ID, seatID).Scan(&n)
+		if n != 1 {
+			http.Error(w, "seat not found for this event", http.StatusNotFound)
+			return
+		}
+
+		var body waitlistReq
+		_ = json.NewDecoder(r.Body).Decode(&body)
+
+		entry, position, err := ticketing.JoinWaitlistSeat(
+			db(ctx, r), seatID, buyer(w, r, body.GuestName, body.GuestEmail).OwnerRef,
+		)
+		if err != nil {
+			ctx.Logger.Error("join seat waitlist", zap.Error(err))
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, map[string]any{"entry": entry, "position": position})
+	}
+}
+
+type claimReq struct {
+	Token      string `json:"token"`
+	GuestName  string `json:"guest_name"`
+	GuestEmail string `json:"guest_email"`
+}
+
+// claimOffer turns a waitlist offer into a pending order, which then captures
+// like any other.
+//
+// The offer is time-boxed. Letting an expired one through would mean the unit it
+// was reserving had already been passed to the next person in the queue.
+func claimOffer(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := loadEvent(ctx, r, r.PathValue("slug")); !ok {
+			http.Error(w, "event not found", http.StatusNotFound)
+			return
+		}
+
+		var body claimReq
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Token == "" {
+			http.Error(w, "token is required", http.StatusBadRequest)
+			return
+		}
+
+		order, err := ticketing.ClaimOffer(
+			db(ctx, r), body.Token,
+			buyer(w, r, body.GuestName, body.GuestEmail), time.Now(),
+		)
+		switch {
+		case errors.Is(err, ticketing.ErrOfferExpired):
+			http.Error(w, "waitlist offer expired or not found", http.StatusGone)
+		case err != nil:
+			ctx.Logger.Error("claim waitlist offer", zap.Error(err))
+			http.Error(w, "server error", http.StatusInternalServerError)
+		default:
+			writeJSON(w, http.StatusCreated, map[string]any{
+				"order": order, "total_cents": order.TotalCents,
+			})
+		}
+	}
+}

--- a/internal/server/booking/webhook.go
+++ b/internal/server/booking/webhook.go
@@ -1,0 +1,133 @@
+package booking
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	kernel "github.com/erancihan/clair/internal/booking"
+	"github.com/erancihan/clair/internal/database/models"
+	api_auth "github.com/erancihan/clair/internal/server/authentication"
+	server_context "github.com/erancihan/clair/internal/server/context"
+	"go.uber.org/zap"
+)
+
+const (
+	// PaymentWebhookSecretEnv names the environment variable holding the shared
+	// secret the payment provider signs its deliveries with. There is no default:
+	// an unset secret disables the webhook rather than falling back to something
+	// guessable, because this endpoint is what turns a hold into a paid ticket.
+	//
+	// It is exported because it is deployment configuration — whoever runs the
+	// application has to set it, and tests have to sign with it.
+	PaymentWebhookSecretEnv = "BOOKING_PAYMENT_WEBHOOK_SECRET"
+
+	// paymentSignatureHeader carries the HMAC-SHA256 digest of the raw body.
+	paymentSignatureHeader = "X-Payment-Signature"
+
+	// maxWebhookBody caps how much of a delivery is read. The body has to be
+	// buffered whole to verify the signature over it, so without a cap an
+	// unauthenticated caller could make the server hold an arbitrary amount.
+	maxWebhookBody = 64 << 10
+)
+
+// paymentEvent is the provider delivery this domain understands.
+//
+// DeliveryID is the provider's own id for the delivery and becomes the payment's
+// idempotency key, which is what makes a retried delivery a no-op instead of a
+// second capture.
+type paymentEvent struct {
+	DeliveryID  string `json:"delivery_id"`
+	OrderID     uint   `json:"order_id"`
+	Kind        string `json:"kind"` // capture|charge
+	AmountCents int64  `json:"amount_cents"`
+	Currency    string `json:"currency"`
+	ProviderRef string `json:"provider_ref"`
+}
+
+// paymentWebhook captures a pending order on a signed delivery from a payment
+// provider.
+//
+// This is the only route that turns money into fulfilment, and it is a machine
+// endpoint: no session, no CSRF token, and therefore no user to authorize. The
+// signature over the raw body is the whole of its authentication, which is why
+// the body is buffered and verified before it is even decoded — a payload that
+// cannot be trusted must not be parsed into a capture.
+//
+// It answers 200 for a delivery it has already seen. Providers retry until they
+// get a success, and reporting an error for a duplicate would have them retry a
+// capture that has already happened.
+func paymentWebhook(ctx server_context.BackEndContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		secret := []byte(os.Getenv(PaymentWebhookSecretEnv))
+		if len(secret) == 0 {
+			ctx.Logger.Error("payment webhook received with no signing secret configured",
+				zap.String("env", PaymentWebhookSecretEnv))
+			http.Error(w, "payment webhook not configured", http.StatusServiceUnavailable)
+			return
+		}
+
+		body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxWebhookBody))
+		if err != nil {
+			http.Error(w, "unreadable request body", http.StatusBadRequest)
+			return
+		}
+
+		if !api_auth.VerifyProviderSignature(secret, body, r.Header.Get(paymentSignatureHeader)) {
+			// The provider is not named in the response, and the reason is not
+			// distinguished from a malformed one: an attacker probing this
+			// endpoint learns nothing beyond "rejected".
+			ctx.Logger.Warn("rejected payment webhook with invalid signature",
+				zap.String("provider", r.PathValue("provider")))
+			http.Error(w, "invalid signature", http.StatusUnauthorized)
+			return
+		}
+
+		var event paymentEvent
+		if err := json.Unmarshal(body, &event); err != nil {
+			http.Error(w, "invalid request payload", http.StatusBadRequest)
+			return
+		}
+		if event.DeliveryID == "" || event.OrderID == 0 {
+			http.Error(w, "delivery_id and order_id are required", http.StatusBadRequest)
+			return
+		}
+
+		conn := db(ctx, r)
+		var order models.BookingOrder
+		if res := conn.Limit(1).Find(&order, event.OrderID); res.RowsAffected == 0 {
+			http.Error(w, "order not found", http.StatusNotFound)
+			return
+		}
+
+		// The order is what the amount is taken from, not the delivery. A payload
+		// that has passed the signature check is authentic, but the price of an
+		// order is this application's to decide.
+		kind := event.Kind
+		if kind == "" {
+			kind = "capture"
+		}
+		payment := models.BookingPayment{
+			Provider:       r.PathValue("provider"),
+			ProviderRef:    event.ProviderRef,
+			Kind:           kind,
+			Status:         "succeeded",
+			AmountCents:    order.TotalCents,
+			Currency:       order.Currency,
+			IdempotencyKey: event.DeliveryID,
+		}
+
+		if err := kernel.CaptureOrder(conn, event.OrderID, payment, time.Now()); err != nil {
+			ctx.Logger.Error("capture order from payment webhook",
+				zap.Uint("order_id", event.OrderID), zap.Error(err))
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{
+			"order_id": event.OrderID, "status": "captured",
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/a-h/templ"
 	"github.com/erancihan/clair/internal/database/models"
 	api_auth "github.com/erancihan/clair/internal/server/authentication"
+	"github.com/erancihan/clair/internal/server/booking"
 	server_context "github.com/erancihan/clair/internal/server/context"
 	"github.com/erancihan/clair/internal/server/games"
 	"github.com/erancihan/clair/internal/utils"
@@ -77,6 +78,7 @@ func (s *backend) Routes() http.Handler {
 	// One line per domain, and nothing else. Anything a domain needs beyond this
 	// line belongs in its own package.
 	games.Mount(app, s.context)
+	booking.Mount(app, s.context)
 
 	return mux
 }

--- a/internal/testsupport/pg.go
+++ b/internal/testsupport/pg.go
@@ -1,0 +1,104 @@
+// Package testsupport provides shared helpers for integration tests that need a
+// real PostgreSQL database (the app is PostgreSQL-only; the booking kernel relies
+// on partial indexes, FOR UPDATE [SKIP LOCKED], and RETURNING).
+//
+// It reads DATABASE_URL (the repo/CI convention; CI provides a postgres:16
+// service), falling back to TEST_DATABASE_URL for local runs. When neither is
+// set, tests that call PostgresDB are skipped (not failed).
+package testsupport
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// dsn resolves the Postgres connection string: DATABASE_URL first (matches CI and
+// the app), then TEST_DATABASE_URL.
+func dsn() string {
+	if v := os.Getenv("DATABASE_URL"); v != "" {
+		return v
+	}
+	return os.Getenv("TEST_DATABASE_URL")
+}
+
+// PostgresDB returns a *gorm.DB bound to a fresh, isolated schema in the Postgres
+// pointed to by DATABASE_URL (or TEST_DATABASE_URL), migrated for the given
+// models. The schema is dropped on test cleanup, so tests are independent and can
+// run concurrently.
+func PostgresDB(t *testing.T, models ...any) *gorm.DB {
+	t.Helper()
+
+	base := dsn()
+	if base == "" {
+		t.Skip("DATABASE_URL/TEST_DATABASE_URL not set; skipping Postgres integration test")
+	}
+
+	schema := schemaName(t.Name())
+
+	// Bootstrap connection (default search_path) to (re)create the schema.
+	boot, err := gorm.Open(postgres.Open(base), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("connect (bootstrap): %v", err)
+	}
+	if err := boot.Exec("DROP SCHEMA IF EXISTS " + schema + " CASCADE").Error; err != nil {
+		t.Fatalf("drop schema: %v", err)
+	}
+	if err := boot.Exec("CREATE SCHEMA " + schema).Error; err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+
+	// Working connection pinned to the schema via search_path (applies to every
+	// pooled connection, so concurrent goroutines all target the same schema).
+	db, err := gorm.Open(postgres.Open(withSearchPath(base, schema)),
+		&gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("connect (schema): %v", err)
+	}
+	if len(models) > 0 {
+		if err := db.AutoMigrate(models...); err != nil {
+			t.Fatalf("migrate: %v", err)
+		}
+	}
+
+	t.Cleanup(func() {
+		_ = boot.Exec("DROP SCHEMA IF EXISTS " + schema + " CASCADE").Error
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+		if sqlDB, err := boot.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+	return db
+}
+
+// schemaName derives a safe, unique-per-test Postgres schema identifier.
+func schemaName(testName string) string {
+	var b strings.Builder
+	b.WriteString("t_")
+	for _, r := range strings.ToLower(testName) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	s := b.String()
+	if len(s) > 60 { // Postgres identifiers max 63 bytes
+		s = s[:60]
+	}
+	return s
+}
+
+func withSearchPath(base, schema string) string {
+	sep := "?"
+	if strings.Contains(base, "?") {
+		sep = "&"
+	}
+	return base + sep + "search_path=" + schema
+}

--- a/internal/ticketing/event.go
+++ b/internal/ticketing/event.go
@@ -1,0 +1,101 @@
+// Package ticketing is the ticketing domain: events with GA pools and assigned
+// seats, over the shared booking reservation kernel. It never imports net/http.
+package ticketing
+
+import (
+	"errors"
+	"time"
+
+	"github.com/erancihan/clair/internal/booking"
+	"github.com/erancihan/clair/internal/database/models"
+	"gorm.io/gorm"
+)
+
+var (
+	// ErrInvalidSeat means a requested seat is missing or not sellable.
+	ErrInvalidSeat = errors.New("ticketing: invalid or non-sellable seat")
+	// ErrInvalidTier means a tier kind is not ga|seated.
+	ErrInvalidTier = errors.New("ticketing: tier kind must be ga or seated")
+)
+
+// SeatInput describes a seat to create under a seated tier.
+type SeatInput struct {
+	Label, Section, RowName string
+	Number                  int
+}
+
+// TierInput describes a tier to create under an event.
+type TierInput struct {
+	Name       string
+	Kind       string // "ga" | "seated"
+	PriceCents int64
+	Currency   string
+	Capacity   int         // GA pool size (kind=ga)
+	Seats      []SeatInput // seats (kind=seated)
+}
+
+// EventInput describes a new event and its tiers.
+type EventInput struct {
+	OwnerID     uint
+	Slug, Name  string
+	StartAt     time.Time
+	Timezone    string
+	MaxPerBuyer int
+	Tiers       []TierInput
+}
+
+// CreateEvent creates an event with its tiers, eagerly materializing a pooled
+// inventory per GA tier and a capacity-1 inventory per seat.
+func CreateEvent(db *gorm.DB, in EventInput) (*models.BookingEvent, error) {
+	tz := in.Timezone
+	if tz == "" {
+		tz = "UTC"
+	}
+	ev := &models.BookingEvent{
+		OwnerID: in.OwnerID, Slug: in.Slug, Name: in.Name, StartAt: in.StartAt.UTC(),
+		Timezone: tz, Status: "scheduled", MaxPerBuyer: in.MaxPerBuyer,
+	}
+	err := db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(ev).Error; err != nil {
+			return err
+		}
+		for _, ti := range in.Tiers {
+			cur := ti.Currency
+			if cur == "" {
+				cur = "USD"
+			}
+			tier := models.BookingTicketTier{
+				EventID: ev.ID, Name: ti.Name, Kind: ti.Kind, PriceCents: ti.PriceCents, Currency: cur,
+			}
+			if err := tx.Create(&tier).Error; err != nil {
+				return err
+			}
+			switch ti.Kind {
+			case "ga":
+				if _, err := booking.EnsureInventory(tx, booking.TierOwner(tier.ID), ti.Capacity); err != nil {
+					return err
+				}
+			case "seated":
+				for _, si := range ti.Seats {
+					seat := models.BookingSeat{
+						TierID: tier.ID, Label: si.Label, Section: si.Section,
+						RowName: si.RowName, Number: si.Number, Kind: "sellable",
+					}
+					if err := tx.Create(&seat).Error; err != nil {
+						return err
+					}
+					if _, err := booking.EnsureInventory(tx, booking.SeatOwner(seat.ID), 1); err != nil {
+						return err
+					}
+				}
+			default:
+				return ErrInvalidTier
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ev, nil
+}

--- a/internal/ticketing/fulfill.go
+++ b/internal/ticketing/fulfill.go
@@ -1,0 +1,76 @@
+package ticketing
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/erancihan/clair/internal/booking"
+	"github.com/erancihan/clair/internal/database/models"
+	"gorm.io/gorm"
+)
+
+func newCode() string {
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	return "TKT-" + hex.EncodeToString(b)
+}
+
+// ticketFulfiller creates BookingTickets when a ticketing order is captured.
+// One ticket per seat; item.Qty tickets for a GA item. Idempotent: if tickets
+// already exist for the item, it returns without creating more.
+type ticketFulfiller struct{}
+
+func (ticketFulfiller) Fulfill(tx *gorm.DB, order models.BookingOrder, item models.BookingOrderItem, inv models.BookingInventory) (uint, error) {
+	var existing models.BookingTicket
+	if res := tx.Where("order_item_id = ?", item.ID).Limit(1).Find(&existing); res.RowsAffected > 0 {
+		return existing.ID, nil // idempotent
+	}
+
+	switch {
+	case inv.SeatID != nil:
+		var seat models.BookingSeat
+		if err := tx.First(&seat, *inv.SeatID).Error; err != nil {
+			return 0, err
+		}
+		var tier models.BookingTicketTier
+		if err := tx.First(&tier, seat.TierID).Error; err != nil {
+			return 0, err
+		}
+		seatID := seat.ID
+		ticket := models.BookingTicket{
+			OrderItemID: item.ID, EventID: tier.EventID, TierID: tier.ID, SeatID: &seatID,
+			Code: newCode(), HolderName: order.BuyerName, HolderEmail: order.BuyerEmail, Status: "valid",
+		}
+		if err := tx.Create(&ticket).Error; err != nil {
+			return 0, err
+		}
+		return ticket.ID, nil
+
+	case inv.TierID != nil:
+		var tier models.BookingTicketTier
+		if err := tx.First(&tier, *inv.TierID).Error; err != nil {
+			return 0, err
+		}
+		firstID := uint(0)
+		for i := 0; i < item.Qty; i++ {
+			ticket := models.BookingTicket{
+				OrderItemID: item.ID, EventID: tier.EventID, TierID: tier.ID,
+				Code: newCode(), HolderName: order.BuyerName, HolderEmail: order.BuyerEmail, Status: "valid",
+			}
+			if err := tx.Create(&ticket).Error; err != nil {
+				return 0, err
+			}
+			if firstID == 0 {
+				firstID = ticket.ID
+			}
+		}
+		return firstID, nil
+	}
+	return 0, fmt.Errorf("ticketing: inventory %d has no seat/tier owner", inv.ID)
+}
+
+func init() {
+	booking.RegisterFulfiller("seat", ticketFulfiller{})
+	booking.RegisterFulfiller("tier", ticketFulfiller{})
+}

--- a/internal/ticketing/hold.go
+++ b/internal/ticketing/hold.go
@@ -1,0 +1,153 @@
+package ticketing
+
+import (
+	"errors"
+	"sort"
+	"time"
+
+	"github.com/erancihan/clair/internal/booking"
+	"github.com/erancihan/clair/internal/database/models"
+	"gorm.io/gorm"
+)
+
+// Buyer identifies who is reserving and their contact details.
+type Buyer struct {
+	OwnerRef string // "user:<id>" | "guest:<sid>"
+	UserID   *uint
+	Name     string
+	Email    string
+}
+
+func newOrder(buyer Buyer, total int64, currency string) *models.BookingOrder {
+	return &models.BookingOrder{
+		Domain: "event", OwnerRef: buyer.OwnerRef, UserID: buyer.UserID,
+		BuyerName: buyer.Name, BuyerEmail: buyer.Email, Status: "pending",
+		SubtotalCents: total, TotalCents: total, Currency: currency,
+	}
+}
+
+// HoldGA holds qty units of a GA tier's pooled inventory and opens a pending
+// order. Idempotent per (tier, owner): a repeat call reuses the existing hold
+// and its order.
+func HoldGA(db *gorm.DB, tier *models.BookingTicketTier, qty int, buyer Buyer, ttl time.Duration, now time.Time, maxPerBuyer int) (*models.BookingOrder, *models.BookingHold, error) {
+	if qty < 1 {
+		return nil, nil, errors.New("ticketing: qty must be >= 1")
+	}
+	var order *models.BookingOrder
+	var hold *models.BookingHold
+	err := booking.WithWriteRetry(func() error {
+		return db.Transaction(func(tx *gorm.DB) error {
+			if err := assertBuyerLimit(tx, tier.EventID, buyer.OwnerRef, qty, maxPerBuyer); err != nil {
+				return err
+			}
+			inv, err := booking.InventoryByOwner(tx, booking.TierOwner(tier.ID))
+			if err != nil {
+				return err
+			}
+			h, err := booking.HoldUnitsTx(tx, inv.ID, qty, buyer.OwnerRef, nil, "cart", ttl, now)
+			if err != nil {
+				return err
+			}
+			if h.OrderID != nil { // idempotent reuse of an existing active hold
+				var o models.BookingOrder
+				if err := tx.First(&o, *h.OrderID).Error; err != nil {
+					return err
+				}
+				order, hold = &o, h
+				return nil
+			}
+			o := newOrder(buyer, tier.PriceCents*int64(qty), tier.Currency)
+			if err := tx.Create(o).Error; err != nil {
+				return err
+			}
+			if err := tx.Model(&models.BookingHold{}).Where("id = ?", h.ID).Update("order_id", o.ID).Error; err != nil {
+				return err
+			}
+			item := &models.BookingOrderItem{
+				OrderID: o.ID, HoldToken: h.Token, InventoryID: inv.ID, Qty: qty,
+				PriceCents: tier.PriceCents, Status: "reserved",
+			}
+			if err := tx.Create(item).Error; err != nil {
+				return err
+			}
+			order, hold = o, h
+			return nil
+		})
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return order, hold, nil
+}
+
+// HoldSeatGroup holds a set of assigned seats all-or-nothing in one transaction:
+// if any seat is unavailable the whole group rolls back. Seats are acquired in
+// ascending inventory-id order to avoid deadlocks.
+func HoldSeatGroup(db *gorm.DB, eventID uint, seatIDs []uint, buyer Buyer, ttl time.Duration, now time.Time, maxPerBuyer int) (*models.BookingOrder, []string, error) {
+	if len(seatIDs) == 0 {
+		return nil, nil, errors.New("ticketing: no seats requested")
+	}
+	var order *models.BookingOrder
+	var tokens []string
+	err := booking.WithWriteRetry(func() error {
+		tokens = tokens[:0]
+		return db.Transaction(func(tx *gorm.DB) error {
+			if err := assertBuyerLimit(tx, eventID, buyer.OwnerRef, len(seatIDs), maxPerBuyer); err != nil {
+				return err
+			}
+			type entry struct {
+				invID uint
+				price int64
+			}
+			var entries []entry
+			var total int64
+			currency := "USD"
+			for _, sid := range seatIDs {
+				var seat models.BookingSeat
+				if err := tx.First(&seat, sid).Error; err != nil {
+					return ErrInvalidSeat
+				}
+				if seat.Kind != "sellable" {
+					return ErrInvalidSeat
+				}
+				var tier models.BookingTicketTier
+				if err := tx.First(&tier, seat.TierID).Error; err != nil {
+					return err
+				}
+				inv, err := booking.InventoryByOwner(tx, booking.SeatOwner(sid))
+				if err != nil {
+					return err
+				}
+				entries = append(entries, entry{invID: inv.ID, price: tier.PriceCents})
+				total += tier.PriceCents
+				currency = tier.Currency
+			}
+			sort.Slice(entries, func(i, j int) bool { return entries[i].invID < entries[j].invID })
+
+			o := newOrder(buyer, total, currency)
+			if err := tx.Create(o).Error; err != nil {
+				return err
+			}
+			for _, e := range entries {
+				h, err := booking.HoldUnitsTx(tx, e.invID, 1, buyer.OwnerRef, &o.ID, "cart", ttl, now)
+				if err != nil {
+					return err // any failure rolls back the whole group
+				}
+				item := &models.BookingOrderItem{
+					OrderID: o.ID, HoldToken: h.Token, InventoryID: e.invID, Qty: 1,
+					PriceCents: e.price, Status: "reserved",
+				}
+				if err := tx.Create(item).Error; err != nil {
+					return err
+				}
+				tokens = append(tokens, h.Token)
+			}
+			order = o
+			return nil
+		})
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return order, tokens, nil
+}

--- a/internal/ticketing/ticketing_test.go
+++ b/internal/ticketing/ticketing_test.go
@@ -1,0 +1,270 @@
+package ticketing_test
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/erancihan/clair/internal/booking"
+	"github.com/erancihan/clair/internal/database"
+	"github.com/erancihan/clair/internal/database/models"
+	"github.com/erancihan/clair/internal/testsupport"
+	"github.com/erancihan/clair/internal/ticketing"
+	"gorm.io/gorm"
+)
+
+func ticketDB(t *testing.T) *gorm.DB {
+	db := testsupport.PostgresDB(t, database.MigrationModels()...)
+	return db
+}
+
+func gaTier(t *testing.T, db *gorm.DB, capacity int) *models.BookingTicketTier {
+	t.Helper()
+	ev, err := ticketing.CreateEvent(db, ticketing.EventInput{
+		OwnerID: 1, Slug: "ev-ga", Name: "Concert", StartAt: time.Now().Add(24 * time.Hour),
+		Tiers: []ticketing.TierInput{{Name: "GA", Kind: "ga", PriceCents: 8000, Capacity: capacity}},
+	})
+	if err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+	var tier models.BookingTicketTier
+	db.Where("event_id = ?", ev.ID).First(&tier)
+	return &tier
+}
+
+func seatedEvent(t *testing.T, db *gorm.DB, labels ...string) []models.BookingSeat {
+	t.Helper()
+	seats := make([]ticketing.SeatInput, len(labels))
+	for i, l := range labels {
+		seats[i] = ticketing.SeatInput{Label: l, Section: "Orchestra", RowName: "A", Number: i + 1}
+	}
+	ev, err := ticketing.CreateEvent(db, ticketing.EventInput{
+		OwnerID: 1, Slug: "ev-seated", Name: "Cinema", StartAt: time.Now().Add(24 * time.Hour),
+		Tiers: []ticketing.TierInput{{Name: "Orchestra", Kind: "seated", PriceCents: 12000, Seats: seats}},
+	})
+	if err != nil {
+		t.Fatalf("create seated event: %v", err)
+	}
+	var out []models.BookingSeat
+	db.Joins("JOIN booking_ticket_tiers t ON t.id = booking_seats.tier_id").
+		Where("t.event_id = ?", ev.ID).Order("number").Find(&out)
+	return out
+}
+
+func TestHoldGA_NoOversell(t *testing.T) {
+	db := ticketDB(t)
+	const cap = 5
+	tier := gaTier(t, db, cap)
+	now := time.Now()
+
+	const N = 40
+	var wg sync.WaitGroup
+	var success int64
+	for i := 0; i < N; i++ {
+		buyer := ticketing.Buyer{OwnerRef: fmt.Sprintf("guest:%d", i)}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, _, err := ticketing.HoldGA(db, tier, 1, buyer, time.Hour, now, 0); err == nil {
+				atomic.AddInt64(&success, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if success != cap {
+		t.Fatalf("GA pool=%d but %d holds succeeded", cap, success)
+	}
+	inv, _ := booking.InventoryByOwner(db, booking.TierOwner(tier.ID))
+	if inv.Held != cap {
+		t.Fatalf("held=%d, want %d", inv.Held, cap)
+	}
+}
+
+func TestHoldSeatGroup_AllOrNothing(t *testing.T) {
+	db := ticketDB(t)
+	seats := seatedEvent(t, db, "A-1", "A-2", "A-3")
+	now := time.Now()
+
+	// Buyer 1 takes A-1 + A-2.
+	if _, _, err := ticketing.HoldSeatGroup(db, 0, []uint{seats[0].ID, seats[1].ID},
+		ticketing.Buyer{OwnerRef: "guest:b1"}, time.Hour, now, 0); err != nil {
+		t.Fatalf("buyer1 hold: %v", err)
+	}
+
+	// Buyer 2 wants A-2 + A-3; A-2 is taken → the WHOLE group must fail and A-3
+	// must stay free (no lone seat).
+	if _, _, err := ticketing.HoldSeatGroup(db, 0, []uint{seats[1].ID, seats[2].ID},
+		ticketing.Buyer{OwnerRef: "guest:b2"}, time.Hour, now, 0); err != booking.ErrSoldOut {
+		t.Fatalf("buyer2 hold: got %v, want ErrSoldOut", err)
+	}
+
+	inv3, _ := booking.InventoryByOwner(db, booking.SeatOwner(seats[2].ID))
+	if inv3.Held != 0 || inv3.Booked != 0 {
+		t.Fatalf("A-3 should be untouched, got held=%d booked=%d", inv3.Held, inv3.Booked)
+	}
+	inv1, _ := booking.InventoryByOwner(db, booking.SeatOwner(seats[0].ID))
+	inv2, _ := booking.InventoryByOwner(db, booking.SeatOwner(seats[1].ID))
+	if inv1.Held != 1 || inv2.Held != 1 {
+		t.Fatalf("A-1/A-2 should be held by buyer1, got %d/%d", inv1.Held, inv2.Held)
+	}
+}
+
+func TestCapture_GA_CreatesTickets(t *testing.T) {
+	db := ticketDB(t)
+	tier := gaTier(t, db, 10)
+	now := time.Now()
+
+	order, _, err := ticketing.HoldGA(db, tier, 3, ticketing.Buyer{OwnerRef: "guest:x", Name: "Ada", Email: "ada@x.com"}, time.Hour, now, 0)
+	if err != nil {
+		t.Fatalf("hold GA: %v", err)
+	}
+	pay := models.BookingPayment{Provider: "mock", Kind: "capture", Status: "succeeded", AmountCents: 24000, IdempotencyKey: "evt-ga"}
+	if err := booking.CaptureOrder(db, order.ID, pay, now); err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+
+	var tickets int64
+	db.Model(&models.BookingTicket{}).Where("tier_id = ?", tier.ID).Count(&tickets)
+	if tickets != 3 {
+		t.Fatalf("want 3 GA tickets, got %d", tickets)
+	}
+	inv, _ := booking.InventoryByOwner(db, booking.TierOwner(tier.ID))
+	if inv.Held != 0 || inv.Booked != 3 {
+		t.Fatalf("after capture held=%d booked=%d, want held=0 booked=3", inv.Held, inv.Booked)
+	}
+
+	// idempotent capture: still 3 tickets.
+	if err := booking.CaptureOrder(db, order.ID, pay, now); err != nil {
+		t.Fatalf("dup capture: %v", err)
+	}
+	db.Model(&models.BookingTicket{}).Where("tier_id = ?", tier.ID).Count(&tickets)
+	if tickets != 3 {
+		t.Fatalf("duplicate capture changed ticket count to %d", tickets)
+	}
+}
+
+func gaTierMax(t *testing.T, db *gorm.DB, capacity, maxPerBuyer int) *models.BookingTicketTier {
+	t.Helper()
+	ev, err := ticketing.CreateEvent(db, ticketing.EventInput{
+		OwnerID: 1, Slug: "ev-max", Name: "Concert", StartAt: time.Now().Add(24 * time.Hour),
+		MaxPerBuyer: maxPerBuyer,
+		Tiers:       []ticketing.TierInput{{Name: "GA", Kind: "ga", PriceCents: 8000, Capacity: capacity}},
+	})
+	if err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+	var tier models.BookingTicketTier
+	db.Where("event_id = ?", ev.ID).First(&tier)
+	return &tier
+}
+
+func TestWaitlist_OfferClaimCapture(t *testing.T) {
+	db := ticketDB(t)
+	tier := gaTier(t, db, 1) // capacity 1
+	inv, _ := booking.InventoryByOwner(db, booking.TierOwner(tier.ID))
+	base := time.Now()
+
+	// Buyer A holds the only unit (short TTL so it expires soon).
+	if _, _, err := ticketing.HoldGA(db, tier, 1, ticketing.Buyer{OwnerRef: "guest:a"}, time.Minute, base, 0); err != nil {
+		t.Fatalf("hold A: %v", err)
+	}
+	// Buyer B joins the waitlist.
+	_, pos, err := booking.JoinWaitlist(db, inv.ID, "guest:b")
+	if err != nil || pos != 1 {
+		t.Fatalf("join waitlist: pos=%d err=%v", pos, err)
+	}
+
+	// After A's hold expires, the reaper frees the unit → offered to B.
+	later := base.Add(2 * time.Minute)
+	if _, err := booking.ReapExpiredHolds(db, later); err != nil {
+		t.Fatalf("reap: %v", err)
+	}
+	var entry models.BookingWaitlistEntry
+	db.Where("owner_ref = ? AND status = 'offered'", "guest:b").First(&entry)
+	if entry.OfferToken == nil {
+		t.Fatal("buyer B was not offered the freed unit")
+	}
+	// The unit is reserved for B (held), not open.
+	db.First(inv, inv.ID)
+	if inv.Held != 1 || inv.Booked != 0 {
+		t.Fatalf("after offer held=%d booked=%d, want held=1 booked=0", inv.Held, inv.Booked)
+	}
+
+	// B claims the offer and captures → B gets the ticket.
+	order, err := ticketing.ClaimOffer(db, *entry.OfferToken, ticketing.Buyer{OwnerRef: "guest:b", Name: "Bob"}, later)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	pay := models.BookingPayment{Provider: "mock", Kind: "capture", Status: "succeeded", IdempotencyKey: "wl-1"}
+	if err := booking.CaptureOrder(db, order.ID, pay, later); err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	var ticket models.BookingTicket
+	if res := db.Where("tier_id = ?", tier.ID).Limit(1).Find(&ticket); res.RowsAffected != 1 || ticket.HolderName != "Bob" {
+		t.Fatalf("expected Bob's ticket, got %+v (rows=%d)", ticket, res.RowsAffected)
+	}
+	db.First(inv, inv.ID)
+	if inv.Booked != 1 {
+		t.Fatalf("after claim+capture booked=%d, want 1", inv.Booked)
+	}
+}
+
+func TestPerBuyerLimit(t *testing.T) {
+	db := ticketDB(t)
+	tier := gaTierMax(t, db, 10, 4) // pool 10, max 4 per buyer
+	now := time.Now()
+	buyer := ticketing.Buyer{OwnerRef: "guest:greedy"}
+
+	// qty 5 in one shot exceeds the cap.
+	if _, _, err := ticketing.HoldGA(db, tier, 5, buyer, time.Hour, now, 4); err != ticketing.ErrPurchaseLimit {
+		t.Fatalf("hold 5: got %v, want ErrPurchaseLimit", err)
+	}
+	// qty 3 is fine; capture it.
+	order, _, err := ticketing.HoldGA(db, tier, 3, buyer, time.Hour, now, 4)
+	if err != nil {
+		t.Fatalf("hold 3: %v", err)
+	}
+	pay := models.BookingPayment{Provider: "mock", Kind: "capture", Status: "succeeded", IdempotencyKey: "lim-1"}
+	if err := booking.CaptureOrder(db, order.ID, pay, now); err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	// Now 3 are fulfilled; a further 2 would be 5 > 4 → rejected.
+	if _, _, err := ticketing.HoldGA(db, tier, 2, buyer, time.Hour, now, 4); err != ticketing.ErrPurchaseLimit {
+		t.Fatalf("hold 2 more: got %v, want ErrPurchaseLimit", err)
+	}
+	// But 1 more (total 4) is allowed.
+	if _, _, err := ticketing.HoldGA(db, tier, 1, buyer, time.Hour, now, 4); err != nil {
+		t.Fatalf("hold 1 more (total 4): %v", err)
+	}
+}
+
+func TestCapture_Seated_CreatesTicketPerSeat(t *testing.T) {
+	db := ticketDB(t)
+	seats := seatedEvent(t, db, "A-1", "A-2")
+	now := time.Now()
+
+	order, _, err := ticketing.HoldSeatGroup(db, 0, []uint{seats[0].ID, seats[1].ID},
+		ticketing.Buyer{OwnerRef: "guest:x", Name: "Ada"}, time.Hour, now, 0)
+	if err != nil {
+		t.Fatalf("hold seats: %v", err)
+	}
+	pay := models.BookingPayment{Provider: "mock", Kind: "capture", Status: "succeeded", AmountCents: 24000, IdempotencyKey: "evt-seat"}
+	if err := booking.CaptureOrder(db, order.ID, pay, now); err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+
+	var tickets []models.BookingTicket
+	db.Where("seat_id IS NOT NULL").Find(&tickets)
+	if len(tickets) != 2 {
+		t.Fatalf("want 2 seated tickets, got %d", len(tickets))
+	}
+	for _, seat := range seats {
+		inv, _ := booking.InventoryByOwner(db, booking.SeatOwner(seat.ID))
+		if inv.Booked != 1 || inv.Held != 0 {
+			t.Fatalf("seat %s after capture held=%d booked=%d, want held=0 booked=1", seat.Label, inv.Held, inv.Booked)
+		}
+	}
+}

--- a/internal/ticketing/waitlist.go
+++ b/internal/ticketing/waitlist.go
@@ -1,0 +1,131 @@
+package ticketing
+
+import (
+	"errors"
+	"time"
+
+	"github.com/erancihan/clair/internal/booking"
+	"github.com/erancihan/clair/internal/database/models"
+	"gorm.io/gorm"
+)
+
+var (
+	// ErrPurchaseLimit means the buyer would exceed the event's per-buyer cap.
+	ErrPurchaseLimit = errors.New("ticketing: per-buyer purchase limit exceeded")
+	// ErrOfferExpired means a waitlist offer is no longer claimable.
+	ErrOfferExpired = errors.New("ticketing: waitlist offer expired or not found")
+)
+
+// assertBuyerLimit enforces an event's MaxPerBuyer inside the hold transaction.
+// It counts the buyer's live units for the event — currently-held (active hold)
+// plus already-fulfilled — so expired/released holds don't count.
+func assertBuyerLimit(tx *gorm.DB, eventID uint, ownerRef string, addQty, max int) error {
+	if max <= 0 {
+		return nil
+	}
+	var have int64
+	tx.Raw(`
+		SELECT COALESCE(SUM(oi.qty), 0)
+		FROM booking_order_items oi
+		JOIN booking_orders o ON o.id = oi.order_id
+		JOIN booking_inventories i ON i.id = oi.inventory_id
+		LEFT JOIN booking_seats s ON s.id = i.seat_id
+		LEFT JOIN booking_holds h ON h.token = oi.hold_token
+		WHERE o.owner_ref = ?
+		  AND (oi.status = 'fulfilled' OR h.status = 'active')
+		  AND COALESCE(i.tier_id, s.tier_id) IN (SELECT id FROM booking_ticket_tiers WHERE event_id = ?)`,
+		ownerRef, eventID).Scan(&have)
+	if int(have)+addQty > max {
+		return ErrPurchaseLimit
+	}
+	return nil
+}
+
+// JoinWaitlistTier adds the buyer to a GA tier's waitlist.
+func JoinWaitlistTier(db *gorm.DB, tier *models.BookingTicketTier, ownerRef string) (*models.BookingWaitlistEntry, int, error) {
+	inv, err := booking.InventoryByOwner(db, booking.TierOwner(tier.ID))
+	if err != nil {
+		return nil, 0, err
+	}
+	return booking.JoinWaitlist(db, inv.ID, ownerRef)
+}
+
+// JoinWaitlistSeat adds the buyer to a specific seat's waitlist.
+func JoinWaitlistSeat(db *gorm.DB, seatID uint, ownerRef string) (*models.BookingWaitlistEntry, int, error) {
+	inv, err := booking.InventoryByOwner(db, booking.SeatOwner(seatID))
+	if err != nil {
+		return nil, 0, err
+	}
+	return booking.JoinWaitlist(db, inv.ID, ownerRef)
+}
+
+// ClaimOffer converts an active waitlist offer into a pending order the buyer
+// can capture. The offer hold already reserves the unit; this attaches an order
+// so the normal capture path issues the ticket.
+func ClaimOffer(db *gorm.DB, token string, buyer Buyer, now time.Time) (*models.BookingOrder, error) {
+	var order *models.BookingOrder
+	err := booking.WithWriteRetry(func() error {
+		return db.Transaction(func(tx *gorm.DB) error {
+			var h models.BookingHold
+			if res := tx.Where("token = ? AND status = 'active' AND purpose = 'waitlist_offer'", token).Limit(1).Find(&h); res.RowsAffected == 0 {
+				return ErrOfferExpired
+			}
+			if !now.Before(h.ExpiresAt) {
+				return ErrOfferExpired
+			}
+			var inv models.BookingInventory
+			if err := tx.First(&inv, h.InventoryID).Error; err != nil {
+				return err
+			}
+			price, currency, err := priceForInventory(tx, inv)
+			if err != nil {
+				return err
+			}
+			o := newOrder(buyer, price*int64(h.Qty), currency)
+			if err := tx.Create(o).Error; err != nil {
+				return err
+			}
+			if err := tx.Model(&models.BookingHold{}).Where("id = ?", h.ID).Update("order_id", o.ID).Error; err != nil {
+				return err
+			}
+			item := &models.BookingOrderItem{
+				OrderID: o.ID, HoldToken: h.Token, InventoryID: inv.ID, Qty: h.Qty,
+				PriceCents: price, Status: "reserved",
+			}
+			if err := tx.Create(item).Error; err != nil {
+				return err
+			}
+			if err := tx.Model(&models.BookingWaitlistEntry{}).Where("offer_token = ?", token).Update("status", "converted").Error; err != nil {
+				return err
+			}
+			order = o
+			return nil
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+	return order, nil
+}
+
+func priceForInventory(tx *gorm.DB, inv models.BookingInventory) (int64, string, error) {
+	switch {
+	case inv.TierID != nil:
+		var tier models.BookingTicketTier
+		if err := tx.First(&tier, *inv.TierID).Error; err != nil {
+			return 0, "", err
+		}
+		return tier.PriceCents, tier.Currency, nil
+	case inv.SeatID != nil:
+		var seat models.BookingSeat
+		if err := tx.First(&seat, *inv.SeatID).Error; err != nil {
+			return 0, "", err
+		}
+		var tier models.BookingTicketTier
+		if err := tx.First(&tier, seat.TierID).Error; err != nil {
+			return 0, "", err
+		}
+		return tier.PriceCents, tier.Currency, nil
+	}
+	return 0, "USD", nil
+}

--- a/test/appointments_http_test.go
+++ b/test/appointments_http_test.go
@@ -1,0 +1,491 @@
+package test
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"html"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/erancihan/clair/internal/database"
+	"github.com/erancihan/clair/internal/database/models"
+	"github.com/erancihan/clair/internal/server"
+	api_auth "github.com/erancihan/clair/internal/server/authentication"
+	"github.com/erancihan/clair/internal/server/booking"
+	"github.com/erancihan/clair/internal/testsupport"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+// newApptServer boots the real Routes() over an isolated Postgres schema and
+// returns an httptest server, a cookie-jar client, and the DB (for assertions).
+// Skips when DATABASE_URL is unset.
+func newApptServer(t *testing.T) (*httptest.Server, *http.Client, *gorm.DB) {
+	db := testsupport.PostgresDB(t, database.MigrationModels()...)
+	handler := server.NewBackEnd(context.Background(), zap.NewNop(), nil, db).Routes()
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	return ts, newJarClient(), db
+}
+
+func newJarClient() *http.Client {
+	jar, _ := cookiejar.New(nil)
+	return &http.Client{
+		Jar:           jar,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+}
+
+// csrfMetaRe matches the token the page shell publishes for browser JS to read.
+var csrfMetaRe = regexp.MustCompile(`<meta name="csrf-token" content="([^"]*)"`)
+
+// csrfToken fetches the CSRF token bound to this client's session the way a
+// browser does: by loading a page and reading the meta tag off it.
+//
+// It has to be fetched per request rather than once per client, because logging
+// in clears the token — it is bound to the session, and the session changes
+// identity at that point.
+func csrfToken(t *testing.T, c *http.Client, targetURL string) string {
+	t.Helper()
+
+	u, err := url.Parse(targetURL)
+	if err != nil {
+		t.Fatalf("parse %s: %v", targetURL, err)
+	}
+
+	resp, err := c.Get(u.Scheme + "://" + u.Host + "/")
+	if err != nil {
+		t.Fatalf("fetch page shell for CSRF token: %v", err)
+	}
+	defer resp.Body.Close()
+
+	page, _ := io.ReadAll(resp.Body)
+	m := csrfMetaRe.FindSubmatch(page)
+	if m == nil {
+		t.Fatal("page shell published no csrf-token meta tag")
+	}
+
+	return html.UnescapeString(string(m[1]))
+}
+
+// doJSON sends a JSON request, attaching a CSRF token on the mutating methods
+// the booking routes require one for. Safe methods are left alone, matching what
+// the middleware enforces.
+func doJSON(t *testing.T, c *http.Client, method, url string, body any) *http.Response {
+	t.Helper()
+	var r io.Reader
+	if body != nil {
+		b, _ := json.Marshal(body)
+		r = bytes.NewReader(b)
+	}
+	req, _ := http.NewRequest(method, url, r)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	// Identify as a JSON client so an authentication failure comes back as a 401
+	// rather than the 302 to /login a browser gets. The auth layer negotiates on
+	// this header, and without it these API calls look like page loads.
+	req.Header.Set("Accept", "application/json")
+	if method != http.MethodGet && method != http.MethodHead {
+		req.Header.Set(api_auth.CSRFHeaderName, csrfToken(t, c, url))
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	return resp
+}
+
+// testPaymentSecret is the shared secret the tests sign mock provider deliveries
+// with. The webhook refuses to run without one configured.
+const testPaymentSecret = "test-payment-webhook-secret"
+
+// capturePayment delivers a signed payment webhook that captures orderID, which
+// is the only route that turns a hold into a booked appointment or a ticket.
+//
+// The signature is computed over the exact bytes sent, since that is what the
+// handler verifies — signing a re-marshalled copy would be a different body.
+func capturePayment(t *testing.T, ts *httptest.Server, orderID uint, deliveryID string) *http.Response {
+	t.Helper()
+	t.Setenv(booking.PaymentWebhookSecretEnv, testPaymentSecret)
+
+	payload, _ := json.Marshal(map[string]any{
+		"delivery_id": deliveryID, "order_id": orderID, "kind": "capture",
+	})
+
+	mac := hmac.New(sha256.New, []byte(testPaymentSecret))
+	mac.Write(payload)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/webhooks/payments/mock", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Payment-Signature", hex.EncodeToString(mac.Sum(nil)))
+
+	// A provider has no session and no cookie jar, so this deliberately does not
+	// go through the browser client used elsewhere in these tests.
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		t.Fatalf("payment webhook: %v", err)
+	}
+	return resp
+}
+
+func mustStatus(t *testing.T, resp *http.Response, want int, ctx string) {
+	t.Helper()
+	if resp.StatusCode != want {
+		b, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("%s: status %d, want %d (%s)", ctx, resp.StatusCode, want, string(b))
+	}
+}
+
+func registerAndLogin(t *testing.T, ts *httptest.Server, c *http.Client, email string) {
+	t.Helper()
+	resp := doJSON(t, c, "POST", ts.URL+"/api/v1/auth/register",
+		map[string]string{"username": "host", "email": email, "password": "pw123456"})
+	resp.Body.Close()
+	resp = doJSON(t, c, "POST", ts.URL+"/api/v1/auth/login",
+		map[string]string{"email": email, "password": "pw123456"})
+	mustStatus(t, resp, http.StatusOK, "login")
+	resp.Body.Close()
+}
+
+// nextMonday09Z returns the next future Monday at 09:00 UTC (aligns with a
+// Mon 09:00–12:00 rule and stays inside the booking window).
+func nextMonday09Z() time.Time {
+	d := time.Now().UTC().AddDate(0, 0, 1)
+	for d.Weekday() != time.Monday {
+		d = d.AddDate(0, 0, 1)
+	}
+	return time.Date(d.Year(), d.Month(), d.Day(), 9, 0, 0, 0, time.UTC)
+}
+
+func mondayRuleSchedule(slug string, extra map[string]any) map[string]any {
+	body := map[string]any{
+		"slug": slug, "name": "Sched", "timezone": "UTC",
+		"slot_duration_min": 30, "capacity": 1, "window_days": 90,
+		"rules": []map[string]int{{"weekday": int(time.Monday), "start_min": 540, "end_min": 720}},
+	}
+	for k, v := range extra {
+		body[k] = v
+	}
+	return body
+}
+
+func TestAppointmentsHTTP_FreeFlow(t *testing.T) {
+	ts, host, _ := newApptServer(t)
+	registerAndLogin(t, ts, host, "free_host@example.com")
+
+	slug := "oh-free"
+	resp := doJSON(t, host, "POST", ts.URL+"/appointments/schedules", mondayRuleSchedule(slug, nil))
+	mustStatus(t, resp, http.StatusCreated, "create schedule")
+	resp.Body.Close()
+
+	start := nextMonday09Z()
+	day := time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, time.UTC)
+	avURL := fmt.Sprintf("%s/appointments/schedules/%s/availability?from=%s&to=%s",
+		ts.URL, slug, day.Format(time.RFC3339), day.AddDate(0, 0, 1).Format(time.RFC3339))
+
+	resp = doJSON(t, host, "GET", avURL, nil)
+	mustStatus(t, resp, http.StatusOK, "availability")
+	var slots []map[string]any
+	json.NewDecoder(resp.Body).Decode(&slots)
+	resp.Body.Close()
+	if len(slots) != 6 {
+		t.Fatalf("want 6 availability slots (09:00–11:30), got %d", len(slots))
+	}
+
+	// A guest books the 09:00 slot.
+	guest := newJarClient()
+	bookBody := map[string]any{"start_at": start.Format(time.RFC3339), "guest_name": "Ada"}
+	resp = doJSON(t, guest, "POST", ts.URL+"/appointments/schedules/"+slug+"/book", bookBody)
+	mustStatus(t, resp, http.StatusCreated, "book")
+	var appt struct {
+		CancelToken string `json:"cancel_token"`
+	}
+	json.NewDecoder(resp.Body).Decode(&appt)
+	resp.Body.Close()
+	if appt.CancelToken == "" {
+		t.Fatal("book response missing cancel_token")
+	}
+
+	// Same slot, capacity 1 → sold out.
+	resp = doJSON(t, newJarClient(), "POST", ts.URL+"/appointments/schedules/"+slug+"/book", bookBody)
+	mustStatus(t, resp, http.StatusConflict, "double book")
+	resp.Body.Close()
+
+	// Cancel frees it; re-book succeeds.
+	resp = doJSON(t, guest, "POST", ts.URL+"/appointments/cancel?token="+appt.CancelToken, nil)
+	mustStatus(t, resp, http.StatusOK, "cancel")
+	resp.Body.Close()
+
+	resp = doJSON(t, newJarClient(), "POST", ts.URL+"/appointments/schedules/"+slug+"/book", bookBody)
+	mustStatus(t, resp, http.StatusCreated, "re-book after cancel")
+	resp.Body.Close()
+}
+
+func TestAppointmentsHTTP_PaidFlow(t *testing.T) {
+	ts, host, db := newApptServer(t)
+	registerAndLogin(t, ts, host, "paid_host@example.com")
+
+	slug := "visa-paid"
+	resp := doJSON(t, host, "POST", ts.URL+"/appointments/schedules", mondayRuleSchedule(slug, map[string]any{
+		"requires_payment": true, "price_cents": 5000, "currency": "USD", "hold_ttl_min": 10,
+	}))
+	mustStatus(t, resp, http.StatusCreated, "create paid schedule")
+	resp.Body.Close()
+
+	start := nextMonday09Z().Format(time.RFC3339)
+
+	// /book is rejected on a paid schedule.
+	resp = doJSON(t, newJarClient(), "POST", ts.URL+"/appointments/schedules/"+slug+"/book",
+		map[string]any{"start_at": start})
+	mustStatus(t, resp, http.StatusBadRequest, "book on paid schedule")
+	resp.Body.Close()
+
+	// A guest holds the slot; capture creates the confirmed appointment.
+	guest := newJarClient()
+	resp = doJSON(t, guest, "POST", ts.URL+"/appointments/schedules/"+slug+"/hold",
+		map[string]any{"start_at": start, "guest_name": "Ada", "guest_email": "ada@example.com"})
+	mustStatus(t, resp, http.StatusCreated, "hold")
+	var held struct {
+		Order struct {
+			ID uint `json:"id"`
+		} `json:"order"`
+	}
+	json.NewDecoder(resp.Body).Decode(&held)
+	resp.Body.Close()
+	if held.Order.ID == 0 {
+		t.Fatal("hold response missing order id")
+	}
+
+	// The slot is reserved during checkout — nobody else can hold it.
+	resp = doJSON(t, newJarClient(), "POST", ts.URL+"/appointments/schedules/"+slug+"/hold",
+		map[string]any{"start_at": start})
+	mustStatus(t, resp, http.StatusConflict, "concurrent hold")
+	resp.Body.Close()
+
+	resp = capturePayment(t, ts, held.Order.ID, "evt-1")
+	mustStatus(t, resp, http.StatusOK, "capture")
+	resp.Body.Close()
+
+	// Re-delivering the same event must not capture a second time. Providers
+	// retry, so this has to be a no-op rather than a duplicate charge.
+	resp = capturePayment(t, ts, held.Order.ID, "evt-1")
+	mustStatus(t, resp, http.StatusOK, "idempotent capture")
+	resp.Body.Close()
+
+	// Exactly one confirmed appointment; order paid; slot committed.
+	var appts int64
+	db.Model(&models.BookingAppointment{}).Where("status = ?", "confirmed").Count(&appts)
+	if appts != 1 {
+		t.Fatalf("want 1 confirmed appointment, got %d", appts)
+	}
+	var order models.BookingOrder
+	db.First(&order, held.Order.ID)
+	if order.Status != "paid" {
+		t.Fatalf("order status=%q, want paid", order.Status)
+	}
+}
+
+func availabilityCount(t *testing.T, c *http.Client, ts *httptest.Server, slug string, day time.Time) int {
+	t.Helper()
+	url := fmt.Sprintf("%s/appointments/schedules/%s/availability?from=%s&to=%s",
+		ts.URL, slug, day.Format(time.RFC3339), day.AddDate(0, 0, 1).Format(time.RFC3339))
+	resp := doJSON(t, c, "GET", url, nil)
+	mustStatus(t, resp, http.StatusOK, "availability")
+	var slots []map[string]any
+	json.NewDecoder(resp.Body).Decode(&slots)
+	resp.Body.Close()
+	return len(slots)
+}
+
+func TestAppointmentsHTTP_RulesAndExceptions(t *testing.T) {
+	ts, host, _ := newApptServer(t)
+	registerAndLogin(t, ts, host, "rules_host@example.com")
+
+	slug := "oh-rules"
+	// Create a schedule with NO rules yet.
+	body := mondayRuleSchedule(slug, nil)
+	body["rules"] = []map[string]int{}
+	resp := doJSON(t, host, "POST", ts.URL+"/appointments/schedules", body)
+	mustStatus(t, resp, http.StatusCreated, "create schedule")
+	resp.Body.Close()
+
+	start := nextMonday09Z()
+	day := time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, time.UTC)
+
+	if n := availabilityCount(t, host, ts, slug, day); n != 0 {
+		t.Fatalf("no rules yet, want 0 slots, got %d", n)
+	}
+
+	// Add a Mon 09:00–12:00 rule → 6 slots.
+	resp = doJSON(t, host, "POST", ts.URL+"/appointments/schedules/"+slug+"/rules",
+		map[string]int{"weekday": int(time.Monday), "start_min": 540, "end_min": 720})
+	mustStatus(t, resp, http.StatusCreated, "add rule")
+	var rule struct {
+		ID uint `json:"id"`
+	}
+	json.NewDecoder(resp.Body).Decode(&rule)
+	resp.Body.Close()
+	if n := availabilityCount(t, host, ts, slug, day); n != 6 {
+		t.Fatalf("after add rule want 6 slots, got %d", n)
+	}
+
+	// Block the whole target Monday → 0 slots.
+	resp = doJSON(t, host, "POST", ts.URL+"/appointments/schedules/"+slug+"/exceptions",
+		map[string]any{"date": start.Format("2006-01-02")})
+	mustStatus(t, resp, http.StatusCreated, "add exception")
+	var ex struct {
+		ID uint `json:"id"`
+	}
+	json.NewDecoder(resp.Body).Decode(&ex)
+	resp.Body.Close()
+	if n := availabilityCount(t, host, ts, slug, day); n != 0 {
+		t.Fatalf("after whole-day block want 0 slots, got %d", n)
+	}
+
+	// Remove the exception → back to 6.
+	resp = doJSON(t, host, "DELETE", fmt.Sprintf("%s/appointments/schedules/%s/exceptions/%d", ts.URL, slug, ex.ID), nil)
+	mustStatus(t, resp, http.StatusNoContent, "delete exception")
+	resp.Body.Close()
+	if n := availabilityCount(t, host, ts, slug, day); n != 6 {
+		t.Fatalf("after delete exception want 6 slots, got %d", n)
+	}
+
+	// Remove the rule → 0.
+	resp = doJSON(t, host, "DELETE", fmt.Sprintf("%s/appointments/schedules/%s/rules/%d", ts.URL, slug, rule.ID), nil)
+	mustStatus(t, resp, http.StatusNoContent, "delete rule")
+	resp.Body.Close()
+	if n := availabilityCount(t, host, ts, slug, day); n != 0 {
+		t.Fatalf("after delete rule want 0 slots, got %d", n)
+	}
+
+	// Ownership: a different user cannot see this schedule's detail.
+	other := newJarClient()
+	registerAndLogin(t, ts, other, "rules_other@example.com")
+	resp = doJSON(t, other, "GET", ts.URL+"/appointments/schedules/"+slug, nil)
+	mustStatus(t, resp, http.StatusNotFound, "other user schedule detail")
+	resp.Body.Close()
+}
+
+func TestAppointmentsHTTP_MyAppointmentsAndBookings(t *testing.T) {
+	ts, host, _ := newApptServer(t)
+	registerAndLogin(t, ts, host, "list_host@example.com")
+
+	slug := "oh-list"
+	resp := doJSON(t, host, "POST", ts.URL+"/appointments/schedules", mondayRuleSchedule(slug, nil))
+	mustStatus(t, resp, http.StatusCreated, "create schedule")
+	resp.Body.Close()
+
+	// A logged-in booker books a slot → appointment is linked to them.
+	booker := newJarClient()
+	registerAndLogin(t, ts, booker, "booker@example.com")
+	start := nextMonday09Z().Format(time.RFC3339)
+	resp = doJSON(t, booker, "POST", ts.URL+"/appointments/schedules/"+slug+"/book",
+		map[string]any{"start_at": start})
+	mustStatus(t, resp, http.StatusCreated, "booker books")
+	resp.Body.Close()
+
+	// Booker sees it in /me.
+	resp = doJSON(t, booker, "GET", ts.URL+"/appointments/me", nil)
+	mustStatus(t, resp, http.StatusOK, "my appointments")
+	var mine []map[string]any
+	json.NewDecoder(resp.Body).Decode(&mine)
+	resp.Body.Close()
+	if len(mine) != 1 {
+		t.Fatalf("booker /me want 1, got %d", len(mine))
+	}
+
+	// A different logged-in user has none.
+	stranger := newJarClient()
+	registerAndLogin(t, ts, stranger, "stranger@example.com")
+	resp = doJSON(t, stranger, "GET", ts.URL+"/appointments/me", nil)
+	mustStatus(t, resp, http.StatusOK, "stranger /me")
+	var none []map[string]any
+	json.NewDecoder(resp.Body).Decode(&none)
+	resp.Body.Close()
+	if len(none) != 0 {
+		t.Fatalf("stranger /me want 0, got %d", len(none))
+	}
+
+	// Host sees the booking; a non-owner cannot.
+	resp = doJSON(t, host, "GET", ts.URL+"/appointments/schedules/"+slug+"/bookings", nil)
+	mustStatus(t, resp, http.StatusOK, "host bookings")
+	var bookings []map[string]any
+	json.NewDecoder(resp.Body).Decode(&bookings)
+	resp.Body.Close()
+	if len(bookings) != 1 {
+		t.Fatalf("host bookings want 1, got %d", len(bookings))
+	}
+	resp = doJSON(t, booker, "GET", ts.URL+"/appointments/schedules/"+slug+"/bookings", nil)
+	mustStatus(t, resp, http.StatusNotFound, "non-owner bookings")
+	resp.Body.Close()
+}
+
+func TestAppointmentsHTTP_PaidCancelRefund(t *testing.T) {
+	ts, host, db := newApptServer(t)
+	registerAndLogin(t, ts, host, "refund_host@example.com")
+
+	slug := "visa-refund"
+	resp := doJSON(t, host, "POST", ts.URL+"/appointments/schedules", mondayRuleSchedule(slug, map[string]any{
+		"requires_payment": true, "price_cents": 5000, "currency": "USD", "hold_ttl_min": 10,
+	}))
+	mustStatus(t, resp, http.StatusCreated, "create paid schedule")
+	resp.Body.Close()
+
+	start := nextMonday09Z().Format(time.RFC3339)
+	guest := newJarClient()
+	resp = doJSON(t, guest, "POST", ts.URL+"/appointments/schedules/"+slug+"/hold",
+		map[string]any{"start_at": start, "guest_name": "Ada"})
+	mustStatus(t, resp, http.StatusCreated, "hold")
+	var held struct {
+		Order struct {
+			ID uint `json:"id"`
+		} `json:"order"`
+	}
+	json.NewDecoder(resp.Body).Decode(&held)
+	resp.Body.Close()
+
+	resp = capturePayment(t, ts, held.Order.ID, "evt-1")
+	mustStatus(t, resp, http.StatusOK, "capture")
+	resp.Body.Close()
+
+	// Grab the created appointment's cancel token (would be emailed in production).
+	var appt models.BookingAppointment
+	db.Where("status = ?", "confirmed").First(&appt)
+	if appt.CancelToken == "" {
+		t.Fatal("no confirmed appointment / cancel token")
+	}
+
+	// Cancel → slot freed, order refunded, refund payment recorded.
+	resp = doJSON(t, guest, "POST", ts.URL+"/appointments/cancel?token="+appt.CancelToken, nil)
+	mustStatus(t, resp, http.StatusOK, "cancel")
+	resp.Body.Close()
+
+	var order models.BookingOrder
+	db.First(&order, held.Order.ID)
+	if order.Status != "refunded" {
+		t.Fatalf("order status=%q, want refunded", order.Status)
+	}
+	var refunds int64
+	db.Model(&models.BookingPayment{}).Where("order_id = ? AND kind = ?", held.Order.ID, "refund").Count(&refunds)
+	if refunds != 1 {
+		t.Fatalf("want 1 refund payment, got %d", refunds)
+	}
+	var inv models.BookingInventory
+	db.Where("slot_id IS NOT NULL").First(&inv)
+	if inv.Booked != 0 {
+		t.Fatalf("after refund booked=%d, want 0 (slot freed)", inv.Booked)
+	}
+}

--- a/test/booking_seam_test.go
+++ b/test/booking_seam_test.go
@@ -1,0 +1,318 @@
+package test
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/erancihan/clair/internal/database/models"
+	"github.com/erancihan/clair/internal/server/booking"
+)
+
+// This file covers the seams the booking domain sits on rather than its booking
+// logic: which routes require what, and how the domain meets the shared
+// authentication layer. The flows themselves are covered by
+// appointments_http_test.go and ticketing_http_test.go.
+
+// TestBooking_RoutesRequireAuth pins the routes that are about one account's own
+// rows. These have to reject an anonymous caller, since there is no account whose
+// schedules or appointments they could be asking for.
+func TestBooking_RoutesRequireAuth(t *testing.T) {
+	ts, _, _ := newApptServer(t)
+
+	cases := []struct {
+		name, method, path string
+		body               any
+	}{
+		{"create schedule", "POST", "/appointments/schedules", mondayRuleSchedule("nope", nil)},
+		{"list schedules", "GET", "/appointments/schedules", nil},
+		{"my appointments", "GET", "/appointments/me", nil},
+		{"create event", "POST", "/events", map[string]any{"slug": "x", "name": "X"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := doJSON(t, newJarClient(), tc.method, ts.URL+tc.path, tc.body)
+			defer resp.Body.Close()
+
+			// A JSON caller gets 401 rather than the browser's redirect to /login,
+			// which is the content negotiation the auth layer performs.
+			if resp.StatusCode != http.StatusUnauthorized {
+				t.Fatalf("anonymous %s %s: status %d, want 401", tc.method, tc.path, resp.StatusCode)
+			}
+		})
+	}
+}
+
+// TestBooking_GuestRoutesAllowAnonymous is the other half of the classification:
+// booking and holding must NOT require an account. Requiring one is precisely the
+// friction this domain exists to avoid, so an anonymous caller reaching these
+// routes has to get a real answer rather than a 401.
+func TestBooking_GuestRoutesAllowAnonymous(t *testing.T) {
+	ts, host, _ := newApptServer(t)
+	registerAndLogin(t, ts, host, "guest_routes_host@example.com")
+
+	slug := "oh-anon"
+	resp := doJSON(t, host, "POST", ts.URL+"/appointments/schedules", mondayRuleSchedule(slug, nil))
+	mustStatus(t, resp, http.StatusCreated, "create schedule")
+	resp.Body.Close()
+
+	guest := newJarClient()
+	resp = doJSON(t, guest, "POST", ts.URL+"/appointments/schedules/"+slug+"/book",
+		map[string]any{"start_at": nextMonday09Z().Format(time.RFC3339), "guest_name": "Ada"})
+	mustStatus(t, resp, http.StatusCreated, "guest books without an account")
+	resp.Body.Close()
+}
+
+// TestBooking_MutatingRoutesRequireCSRF checks that a mutating booking request
+// with no token is refused.
+//
+// A session cookie alone is not enough: browsers attach it to cross-site requests
+// too, so without this check another origin could post here as the signed-in
+// caller. The token has to be presented explicitly.
+func TestBooking_MutatingRoutesRequireCSRF(t *testing.T) {
+	ts, host, _ := newApptServer(t)
+	registerAndLogin(t, ts, host, "csrf_host@example.com")
+
+	// Deliberately bypasses doJSON, which is what attaches the token.
+	body, _ := json.Marshal(mondayRuleSchedule("oh-csrf", nil))
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/appointments/schedules", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := host.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("authenticated POST with no CSRF token: status %d, want 403", resp.StatusCode)
+	}
+}
+
+// TestBooking_CollectionRoutesAreNotSubtrees guards the routing hazard that
+// registering a collection route as "/" inside its group would create.
+//
+// A pattern ending in a slash matches a whole subtree, so "POST
+// /appointments/schedules/" would answer every unmatched POST beneath it: a typo
+// or a probe would reach the create handler. What is asserted here is that the
+// create handler does not run, which is the part that would be a real bug —
+// unmatched paths fall through to the site-wide handler, so the status is that
+// handler's to decide, not this domain's.
+func TestBooking_CollectionRoutesAreNotSubtrees(t *testing.T) {
+	ts, host, db := newApptServer(t)
+	registerAndLogin(t, ts, host, "subtree_host@example.com")
+
+	for _, path := range []string{
+		"/appointments/schedules/some-slug/not-a-route",
+		"/events/some-slug/not-a-route",
+	} {
+		resp := doJSON(t, host, "POST", ts.URL+path,
+			map[string]any{"slug": "subtree-probe", "name": "Probe", "timezone": "UTC",
+				"slot_duration_min": 30, "capacity": 1})
+		resp.Body.Close()
+
+		if resp.StatusCode == http.StatusCreated {
+			t.Errorf("POST %s was handled as a creation (201)", path)
+		}
+	}
+
+	var schedules, events int64
+	db.Model(&models.BookingSchedule{}).Where("slug = ?", "subtree-probe").Count(&schedules)
+	db.Model(&models.BookingEvent{}).Where("slug = ?", "subtree-probe").Count(&events)
+	if schedules != 0 || events != 0 {
+		t.Errorf("unmatched POSTs created rows: %d schedules, %d events", schedules, events)
+	}
+}
+
+// TestBooking_PaymentWebhookRejectsUnsignedDeliveries covers the authentication of
+// the one route that turns a hold into a paid booking.
+//
+// It has no session and no CSRF token, so the signature over the body is the only
+// thing standing between a stranger and a free appointment. Each case here is a
+// way of not having a valid one.
+func TestBooking_PaymentWebhookRejectsUnsignedDeliveries(t *testing.T) {
+	ts, _, _ := newApptServer(t)
+
+	payload, _ := json.Marshal(map[string]any{"delivery_id": "forged-1", "order_id": 1})
+
+	post := func(t *testing.T, signature string) int {
+		t.Helper()
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/webhooks/payments/mock", bytes.NewReader(payload))
+		req.Header.Set("Content-Type", "application/json")
+		if signature != "" {
+			req.Header.Set("X-Payment-Signature", signature)
+		}
+		resp, err := (&http.Client{}).Do(req)
+		if err != nil {
+			t.Fatalf("webhook request failed: %v", err)
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	t.Run("no secret configured", func(t *testing.T) {
+		t.Setenv(booking.PaymentWebhookSecretEnv, "")
+		// Refusing to serve beats accepting deliveries nobody can vouch for.
+		if got := post(t, "deadbeef"); got != http.StatusServiceUnavailable {
+			t.Fatalf("status %d, want 503", got)
+		}
+	})
+
+	t.Run("no signature", func(t *testing.T) {
+		t.Setenv(booking.PaymentWebhookSecretEnv, testPaymentSecret)
+		if got := post(t, ""); got != http.StatusUnauthorized {
+			t.Fatalf("status %d, want 401", got)
+		}
+	})
+
+	t.Run("wrong signature", func(t *testing.T) {
+		t.Setenv(booking.PaymentWebhookSecretEnv, testPaymentSecret)
+
+		// A well-formed signature made with the wrong secret: this is the case a
+		// length or format check would wave through.
+		mac := hmac.New(sha256.New, []byte("not-the-secret"))
+		mac.Write(payload)
+		if got := post(t, hex.EncodeToString(mac.Sum(nil))); got != http.StatusUnauthorized {
+			t.Fatalf("status %d, want 401", got)
+		}
+	})
+
+	t.Run("valid signature over an unknown order", func(t *testing.T) {
+		t.Setenv(booking.PaymentWebhookSecretEnv, testPaymentSecret)
+
+		unknown, _ := json.Marshal(map[string]any{"delivery_id": "d-1", "order_id": 999999})
+		mac := hmac.New(sha256.New, []byte(testPaymentSecret))
+		mac.Write(unknown)
+
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/webhooks/payments/mock", bytes.NewReader(unknown))
+		req.Header.Set("X-Payment-Signature", hex.EncodeToString(mac.Sum(nil)))
+		resp, err := (&http.Client{}).Do(req)
+		if err != nil {
+			t.Fatalf("webhook request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		// Authentic, but about nothing: the signature proves who sent it, not that
+		// the order exists.
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("status %d, want 404", resp.StatusCode)
+		}
+	})
+}
+
+// TestBooking_GuestWorkSurvivesLogin is the guest migrator end to end: somebody
+// holds a paid slot as a guest, then signs in to pay.
+//
+// Without the migrator the hold they are about to pay for is stranded. It is
+// stamped with the guest reference they had when they took it, and every request
+// after login carries their user reference instead — so checkout would be paying
+// for something the account does not own.
+func TestBooking_GuestWorkSurvivesLogin(t *testing.T) {
+	ts, host, db := newApptServer(t)
+	registerAndLogin(t, ts, host, "migrator_host@example.com")
+
+	slug := "oh-migrate"
+	resp := doJSON(t, host, "POST", ts.URL+"/appointments/schedules", mondayRuleSchedule(slug, map[string]any{
+		"requires_payment": true, "price_cents": 5000, "currency": "USD", "hold_ttl_min": 15,
+	}))
+	mustStatus(t, resp, http.StatusCreated, "create paid schedule")
+	resp.Body.Close()
+
+	// A guest holds the slot before having an account at all.
+	guest := newJarClient()
+	resp = doJSON(t, guest, "POST", ts.URL+"/appointments/schedules/"+slug+"/hold",
+		map[string]any{"start_at": nextMonday09Z().Format(time.RFC3339), "guest_name": "Ada"})
+	mustStatus(t, resp, http.StatusCreated, "guest holds slot")
+
+	var held struct {
+		Order     models.BookingOrder `json:"order"`
+		HoldToken string              `json:"hold_token"`
+	}
+	json.NewDecoder(resp.Body).Decode(&held)
+	resp.Body.Close()
+
+	var hold models.BookingHold
+	if err := db.Where("token = ?", held.HoldToken).First(&hold).Error; err != nil {
+		t.Fatalf("load hold: %v", err)
+	}
+	if !isGuestRef(hold.OwnerRef) {
+		t.Fatalf("hold owner_ref %q, want a guest reference before login", hold.OwnerRef)
+	}
+
+	// The same browser now registers and signs in, carrying its guest cookie.
+	email := "migrator_buyer@example.com"
+	resp = doJSON(t, guest, "POST", ts.URL+"/api/v1/auth/register",
+		map[string]string{"username": "buyer", "email": email, "password": "pw123456"})
+	resp.Body.Close()
+	resp = doJSON(t, guest, "POST", ts.URL+"/api/v1/auth/login",
+		map[string]string{"email": email, "password": "pw123456"})
+	mustStatus(t, resp, http.StatusOK, "guest logs in")
+	resp.Body.Close()
+
+	var user models.User
+	if err := db.Where("email = ?", email).First(&user).Error; err != nil {
+		t.Fatalf("load user: %v", err)
+	}
+	wantRef := fmt.Sprintf("user:%d", user.ID)
+
+	if err := db.Where("token = ?", held.HoldToken).First(&hold).Error; err != nil {
+		t.Fatalf("reload hold: %v", err)
+	}
+	if hold.OwnerRef != wantRef {
+		t.Errorf("hold owner_ref %q after login, want %q", hold.OwnerRef, wantRef)
+	}
+
+	var order models.BookingOrder
+	if err := db.First(&order, held.Order.ID).Error; err != nil {
+		t.Fatalf("reload order: %v", err)
+	}
+	if order.OwnerRef != wantRef {
+		t.Errorf("order owner_ref %q after login, want %q", order.OwnerRef, wantRef)
+	}
+	// The order also carries the id as a column, so what a capture fulfils is
+	// linked to the account and not only to the session that started it.
+	if order.UserID == nil || *order.UserID != user.ID {
+		t.Errorf("order user_id %v after login, want %d", order.UserID, user.ID)
+	}
+
+	// Signing in again must not disturb what the first login already moved: the
+	// guest cookie outlives the login, so this runs the migrator a second time.
+	resp = doJSON(t, guest, "POST", ts.URL+"/api/v1/auth/login",
+		map[string]string{"email": email, "password": "pw123456"})
+	mustStatus(t, resp, http.StatusOK, "second login")
+	resp.Body.Close()
+
+	if err := db.Where("token = ?", held.HoldToken).First(&hold).Error; err != nil {
+		t.Fatalf("reload hold after second login: %v", err)
+	}
+	if hold.OwnerRef != wantRef {
+		t.Errorf("hold owner_ref %q after second login, want %q", hold.OwnerRef, wantRef)
+	}
+
+	// And the account can now pay for what it holds.
+	resp = capturePayment(t, ts, held.Order.ID, "migrated-1")
+	mustStatus(t, resp, http.StatusOK, "capture migrated order")
+	resp.Body.Close()
+
+	var appointments []models.BookingAppointment
+	db.Where("status = ?", "confirmed").Find(&appointments)
+	if len(appointments) != 1 {
+		t.Fatalf("want 1 confirmed appointment after capture, got %d", len(appointments))
+	}
+	if appointments[0].UserID == nil || *appointments[0].UserID != user.ID {
+		t.Errorf("appointment user_id %v, want %d", appointments[0].UserID, user.ID)
+	}
+}
+
+// isGuestRef reports whether ref is an anonymous visitor's owner reference, in
+// the "guest:<sid>" form the authentication layer produces.
+func isGuestRef(ref string) bool {
+	return len(ref) > len("guest:") && ref[:len("guest:")] == "guest:"
+}

--- a/test/ticketing_http_test.go
+++ b/test/ticketing_http_test.go
@@ -1,0 +1,260 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/erancihan/clair/internal/booking"
+	"github.com/erancihan/clair/internal/database/models"
+)
+
+type tierResp struct {
+	ID        uint `json:"id"`
+	Remaining int  `json:"remaining"`
+}
+
+func getEventTiers(t *testing.T, c *http.Client, ts, slug string) []tierResp {
+	t.Helper()
+	resp := doJSON(t, c, "GET", ts+"/events/"+slug, nil)
+	mustStatus(t, resp, http.StatusOK, "get event")
+	var body struct {
+		Tiers []tierResp `json:"tiers"`
+	}
+	json.NewDecoder(resp.Body).Decode(&body)
+	resp.Body.Close()
+	return body.Tiers
+}
+
+func TestTicketingHTTP_GA(t *testing.T) {
+	ts, host, db := newApptServer(t)
+	registerAndLogin(t, ts, host, "ga_host@example.com")
+
+	resp := doJSON(t, host, "POST", ts.URL+"/events", map[string]any{
+		"slug": "concert", "name": "Concert", "start_at": time.Now().Add(48 * time.Hour).Format(time.RFC3339),
+		"tiers": []map[string]any{{"name": "GA", "kind": "ga", "price_cents": 8000, "capacity": 3}},
+	})
+	mustStatus(t, resp, http.StatusCreated, "create event")
+	resp.Body.Close()
+
+	tiers := getEventTiers(t, host, ts.URL, "concert")
+	if len(tiers) != 1 || tiers[0].Remaining != 3 {
+		t.Fatalf("want 1 tier, remaining 3, got %+v", tiers)
+	}
+	tierID := tiers[0].ID
+
+	// Guest holds 2 GA tickets.
+	guest := newJarClient()
+	resp = doJSON(t, guest, "POST", fmt.Sprintf("%s/events/concert/tiers/%d/hold", ts.URL, tierID),
+		map[string]any{"qty": 2, "guest_name": "Ada"})
+	mustStatus(t, resp, http.StatusCreated, "hold GA")
+	var held struct {
+		Order struct {
+			ID uint `json:"id"`
+		} `json:"order"`
+	}
+	json.NewDecoder(resp.Body).Decode(&held)
+	resp.Body.Close()
+
+	if r := getEventTiers(t, host, ts.URL, "concert")[0].Remaining; r != 1 {
+		t.Fatalf("after holding 2, remaining want 1, got %d", r)
+	}
+
+	// Capture → 2 tickets issued.
+	resp = capturePayment(t, ts, held.Order.ID, "ga-1")
+	mustStatus(t, resp, http.StatusOK, "capture")
+	resp.Body.Close()
+
+	var tickets int64
+	db.Model(&models.BookingTicket{}).Count(&tickets)
+	if tickets != 2 {
+		t.Fatalf("want 2 tickets, got %d", tickets)
+	}
+	// Over-hold the remaining pool guardrail: ask for 5 → 409.
+	resp = doJSON(t, newJarClient(), "POST", fmt.Sprintf("%s/events/concert/tiers/%d/hold", ts.URL, tierID),
+		map[string]any{"qty": 5})
+	mustStatus(t, resp, http.StatusConflict, "over-hold")
+	resp.Body.Close()
+}
+
+func seatMap(t *testing.T, c *http.Client, ts, slug string) []struct {
+	ID    uint   `json:"id"`
+	Label string `json:"label"`
+	State string `json:"state"`
+} {
+	t.Helper()
+	resp := doJSON(t, c, "GET", ts+"/events/"+slug+"/seats", nil)
+	mustStatus(t, resp, http.StatusOK, "seat map")
+	var seats []struct {
+		ID    uint   `json:"id"`
+		Label string `json:"label"`
+		State string `json:"state"`
+	}
+	json.NewDecoder(resp.Body).Decode(&seats)
+	resp.Body.Close()
+	return seats
+}
+
+func TestTicketingHTTP_Seated(t *testing.T) {
+	ts, host, db := newApptServer(t)
+	registerAndLogin(t, ts, host, "seat_host@example.com")
+
+	resp := doJSON(t, host, "POST", ts.URL+"/events", map[string]any{
+		"slug": "cinema", "name": "Cinema", "start_at": time.Now().Add(48 * time.Hour).Format(time.RFC3339),
+		"tiers": []map[string]any{{
+			"name": "Orchestra", "kind": "seated", "price_cents": 12000,
+			"seats": []map[string]any{
+				{"label": "A-1", "section": "Orchestra", "row_name": "A", "number": 1},
+				{"label": "A-2", "section": "Orchestra", "row_name": "A", "number": 2},
+				{"label": "A-3", "section": "Orchestra", "row_name": "A", "number": 3},
+			},
+		}},
+	})
+	mustStatus(t, resp, http.StatusCreated, "create seated event")
+	resp.Body.Close()
+
+	seats := seatMap(t, host, ts.URL, "cinema")
+	if len(seats) != 3 {
+		t.Fatalf("want 3 seats, got %d", len(seats))
+	}
+	byLabel := map[string]uint{}
+	for _, s := range seats {
+		if s.State != "free" {
+			t.Fatalf("seat %s state=%s, want free", s.Label, s.State)
+		}
+		byLabel[s.Label] = s.ID
+	}
+
+	// Guest 1 holds A-1 + A-2.
+	g1 := newJarClient()
+	resp = doJSON(t, g1, "POST", ts.URL+"/events/cinema/seats/hold",
+		map[string]any{"seat_ids": []uint{byLabel["A-1"], byLabel["A-2"]}, "guest_name": "Ada"})
+	mustStatus(t, resp, http.StatusCreated, "hold seats")
+	var held struct {
+		Order struct {
+			ID uint `json:"id"`
+		} `json:"order"`
+	}
+	json.NewDecoder(resp.Body).Decode(&held)
+	resp.Body.Close()
+
+	// Guest 2 wants A-2 + A-3 → all-or-nothing conflict (A-2 taken); A-3 stays free.
+	resp = doJSON(t, newJarClient(), "POST", ts.URL+"/events/cinema/seats/hold",
+		map[string]any{"seat_ids": []uint{byLabel["A-2"], byLabel["A-3"]}})
+	mustStatus(t, resp, http.StatusConflict, "contended seat hold")
+	resp.Body.Close()
+
+	states := map[string]string{}
+	for _, s := range seatMap(t, host, ts.URL, "cinema") {
+		states[s.Label] = s.State
+	}
+	if states["A-1"] != "held" || states["A-2"] != "held" || states["A-3"] != "free" {
+		t.Fatalf("unexpected seat states: %+v", states)
+	}
+
+	// Capture guest 1 → A-1, A-2 booked; 2 seated tickets.
+	resp = capturePayment(t, ts, held.Order.ID, "seat-1")
+	mustStatus(t, resp, http.StatusOK, "capture")
+	resp.Body.Close()
+
+	states = map[string]string{}
+	for _, s := range seatMap(t, host, ts.URL, "cinema") {
+		states[s.Label] = s.State
+	}
+	if states["A-1"] != "booked" || states["A-2"] != "booked" || states["A-3"] != "free" {
+		t.Fatalf("after capture states: %+v", states)
+	}
+	var tickets int64
+	db.Model(&models.BookingTicket{}).Where("seat_id IS NOT NULL").Count(&tickets)
+	if tickets != 2 {
+		t.Fatalf("want 2 seated tickets, got %d", tickets)
+	}
+}
+
+func TestTicketingHTTP_PerBuyerLimit(t *testing.T) {
+	ts, host, _ := newApptServer(t)
+	registerAndLogin(t, ts, host, "limit_host@example.com")
+
+	resp := doJSON(t, host, "POST", ts.URL+"/events", map[string]any{
+		"slug": "limited", "name": "Limited", "start_at": time.Now().Add(48 * time.Hour).Format(time.RFC3339),
+		"max_per_buyer": 2,
+		"tiers":         []map[string]any{{"name": "GA", "kind": "ga", "price_cents": 8000, "capacity": 10}},
+	})
+	mustStatus(t, resp, http.StatusCreated, "create event")
+	resp.Body.Close()
+	tierID := getEventTiers(t, host, ts.URL, "limited")[0].ID
+
+	guest := newJarClient()
+	// qty 2 is fine.
+	resp = doJSON(t, guest, "POST", fmt.Sprintf("%s/events/limited/tiers/%d/hold", ts.URL, tierID), map[string]any{"qty": 2})
+	mustStatus(t, resp, http.StatusCreated, "hold 2")
+	resp.Body.Close()
+	// The same buyer asking for 1 more exceeds the cap of 2.
+	resp = doJSON(t, guest, "POST", fmt.Sprintf("%s/events/limited/tiers/%d/hold", ts.URL, tierID), map[string]any{"qty": 1})
+	mustStatus(t, resp, http.StatusConflict, "hold beyond limit")
+	resp.Body.Close()
+}
+
+func TestTicketingHTTP_WaitlistClaim(t *testing.T) {
+	ts, host, db := newApptServer(t)
+	registerAndLogin(t, ts, host, "wl_host@example.com")
+
+	resp := doJSON(t, host, "POST", ts.URL+"/events", map[string]any{
+		"slug": "soldout", "name": "SoldOut", "start_at": time.Now().Add(48 * time.Hour).Format(time.RFC3339),
+		"tiers": []map[string]any{{"name": "GA", "kind": "ga", "price_cents": 8000, "capacity": 1}},
+	})
+	mustStatus(t, resp, http.StatusCreated, "create event")
+	resp.Body.Close()
+	tierID := getEventTiers(t, host, ts.URL, "soldout")[0].ID
+
+	// Buyer 1 grabs the only unit.
+	g1 := newJarClient()
+	resp = doJSON(t, g1, "POST", fmt.Sprintf("%s/events/soldout/tiers/%d/hold", ts.URL, tierID), map[string]any{"qty": 1})
+	mustStatus(t, resp, http.StatusCreated, "hold")
+	resp.Body.Close()
+
+	// Buyer 2 joins the waitlist.
+	g2 := newJarClient()
+	resp = doJSON(t, g2, "POST", fmt.Sprintf("%s/events/soldout/tiers/%d/waitlist", ts.URL, tierID), map[string]any{"guest_name": "Bob"})
+	mustStatus(t, resp, http.StatusCreated, "join waitlist")
+	var wl struct {
+		Position int `json:"position"`
+	}
+	json.NewDecoder(resp.Body).Decode(&wl)
+	resp.Body.Close()
+	if wl.Position != 1 {
+		t.Fatalf("waitlist position=%d, want 1", wl.Position)
+	}
+
+	// Simulate the reaper firing after buyer 1's hold expires → offered to B.
+	if _, err := booking.ReapExpiredHolds(db, time.Now().Add(11*time.Minute)); err != nil {
+		t.Fatalf("reap: %v", err)
+	}
+	var entry models.BookingWaitlistEntry
+	if res := db.Where("status = ?", "offered").Limit(1).Find(&entry); res.RowsAffected != 1 || entry.OfferToken == nil {
+		t.Fatalf("no waitlist offer created (rows=%d)", res.RowsAffected)
+	}
+
+	// Buyer 2 claims the offer, then captures.
+	resp = doJSON(t, g2, "POST", ts.URL+"/events/soldout/waitlist/claim", map[string]string{"token": *entry.OfferToken, "guest_name": "Bob"})
+	mustStatus(t, resp, http.StatusCreated, "claim")
+	var claimed struct {
+		Order struct {
+			ID uint `json:"id"`
+		} `json:"order"`
+	}
+	json.NewDecoder(resp.Body).Decode(&claimed)
+	resp.Body.Close()
+
+	resp = capturePayment(t, ts, claimed.Order.ID, "wl-http-1")
+	mustStatus(t, resp, http.StatusOK, "capture")
+	resp.Body.Close()
+
+	var tickets int64
+	db.Model(&models.BookingTicket{}).Count(&tickets)
+	if tickets != 1 {
+		t.Fatalf("want 1 ticket after claim+capture, got %d", tickets)
+	}
+}


### PR DESCRIPTION
## What this is

A generic booking system built on a shared **reservation kernel**, with two domains on top:

- **Appointments** — "office hours"/visa-style scheduling (free direct-book **and** paid hold-then-pay).
- **Ticketing** — events with GA pools and assigned seats.

Design docs live on the `docs/booking-system-design` branch. This PR is the implementation.

**Stack:** Go 1.25 · GORM · PostgreSQL · Valkey-ready. All feature tables are prefixed `booking_*` to coexist with the parallel shopfront's `shop_*` namespace.

> **Rebased onto `master@137bf94`** and restructured onto the merged auth layer (#15) and integration seam (#16). Force-pushed, so earlier review comments may show as outdated.

## Architecture

```
internal/database/models/booking_*.go   # 15 models, one file each, domain-prefixed
internal/booking                        # shared kernel — inventory, holds, orders,
                                        #   payments, capture/fulfil, reaper, waitlist
internal/appointments                   # DST-correct availability + free/paid booking
internal/ticketing                      # events, GA pools, assigned seats, tickets
internal/server/booking                 # Mount + Models seam, handlers, webhook,
                                        #   guest migrator
internal/testsupport                    # Postgres harness (isolated schema per test)
```

The kernel's core is one **atomic capacity guard** (`booked + held + blocked <= capacity`) plus expiring **holds**. Every domain reserves through it, so oversell protection lives in one place instead of once per domain.

## Integration with the shared layers

Follows `internal/server/games` as the reference implementation:

- **`Mount` + `Models` seam** — the domain owns its whole path space and its own migration list. The two shared files cost **one line each** (`server.go`, `database.go`); nothing else outside the domain's own lane is touched.
- **Identity** — uses `api_auth.CurrentUser` / `OwnerRef` / `SessionID`. The local `CurrentUser` accessor and `internal/server/context/user.go` are deleted.
- **Guest → account** — a `RegisterGuestMigrator("booking", …)` hands a guest's active holds, pending orders and waitlist positions to the account on login, so somebody who picks a seat and *then* signs in to pay keeps what they were paying for. Idempotent, because the guest cookie outlives the login.
- **Partial indexes** — the two partial unique indexes backing hold and waitlist idempotency are expressed as GORM index tags with a `where` option, so `AutoMigrate` creates them and the domain needs no migration hook (verified against real Postgres).

### Route classification

The security decision is recorded explicitly in `mount.go`:

| Class | Routes | Enforcement |
|---|---|---|
| Public reads | availability, event, seat map | none |
| **Guest-allowed writes** | book, hold, cancel-by-token, join waitlist, claim offer | `CSRF` only — deliberately no account required |
| Authenticated | schedule management, `/appointments/me`, create event | `AuthMiddleware` + `CSRF` |
| Machine | payment webhook | HMAC-SHA256 signature over the raw body |

Guest-allowed writes are the point: making an appointment is what a first-time visitor does, and requiring an account first is the friction this system exists to remove. Ownership follows `OwnerRef` either way.

## Payment capture is now a signed webhook

The previous **mock capture endpoints are gone** — they were unauthenticated, so anyone could capture any order for free. Replaced by `POST /webhooks/payments/{provider}`:

- Body is buffered and the signature verified **before** it is decoded — a payload that cannot be trusted must not be parsed into a capture.
- Body size is capped (the body must be buffered whole to verify it).
- The charged amount comes from the **order**, not the delivery.
- An unset `BOOKING_PAYMENT_WEBHOOK_SECRET` disables the route (503) rather than falling back to something guessable. Documented in `.env.example`.
- Re-delivery is a no-op via the payment idempotency key, and answers 200 so providers stop retrying.

## Correctness highlights

- **No oversell** under real concurrent Postgres connections (direct-book, GA pools, seat groups).
- **Capture-time commit** — inventory is confirmed on payment capture, not before.
- **Hold reclaim** uses a `RETURNING` CTE rather than a snapshot-dependent `SUM` recompute — this fixed a real `READ COMMITTED` oversell the tests caught.
- **Deadlock-free** multi-seat holds (ascending inventory-id acquisition order).
- **Collection routes are not subtree patterns.** Registering `"/"` inside a group yields `POST /appointments/schedules/`, which matches a whole subtree — every unmatched POST beneath it would reach the create handler. Fixed, and pinned by a test.

## Testing

**146 tests/subtests pass, zero failures**, including the auth and seam tests already on master. All four CI steps verified locally (`go generate`, `go vet`, `CGO_ENABLED=0 go build`, `make test`).

- **Unit** — DST availability (incl. spring-forward), money/slot math.
- **Integration (Postgres)** — no-oversell under concurrency, hold reclaim/commit idempotency, capture→fulfil, waitlist offer/claim, per-buyer limits. Concurrency suites run 6× consecutively without flaking.
- **HTTP end-to-end** — drives the real `Routes()`, obtaining a CSRF token the way a browser does (loading a page, reading the `<meta name="csrf-token">`) and capturing through the signed webhook.
- **Seam tests** (`test/booking_seam_test.go`) — auth classification both ways, CSRF rejection, the subtree-pattern regression, webhook rejection (no signature / wrong secret / no secret configured), and the guest migrator end to end including a repeat login.

## Note for a follow-up (pre-existing, not in this PR)

`mountPages` in `server.go` renders the not-found **page** for unmatched paths but never sets a 404 **status** — it answers `200`. The comment there says it intends a 404 response. Left alone since `server.go` is shared and outside this PR's lane, but worth a one-line fix.

## Not included (deferred, clearly marked)

- **Real payment provider integration** — the webhook and its verification are complete; no specific provider's payload format is wired up.
- **Valkey acceleration** — seat fast-locks / on-sale waiting room. The database is already authoritative; these are performance layers.
- **Booking UI pages** — the domain is API-only so far; `PageShell` is ready for when pages land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeHSq8okvEhb57PnE5umGE)_