### PR TITLE
feat(auth): unified authentication & identity layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,12 @@
+# Application environment. Set to "production" to enable fail-closed security
+# (a SESSION_KEY becomes mandatory and cookies are marked Secure).
 APP_ENV=development
+
+# Session / security configuration
+## Signing key for session cookies. REQUIRED when APP_ENV=production (the server
+## panics on startup if it is unset). Outside production a development fallback is
+## used. Generate one with, e.g., `openssl rand -base64 48`.
+SESSION_KEY=
 
 # Database configuration
 ## PostgreSQL connection string (required)

--- a/internal/database/models/users.go
+++ b/internal/database/models/users.go
@@ -8,7 +8,10 @@ type User struct {
 	ID       uint   `json:"id" gorm:"primaryKey"`
 	Username string `json:"username"`
 	Email    string `json:"email" gorm:"uniqueIndex"`
-	Password string `json:"password"`
+	// Password holds the bcrypt hash and is never serialized: this struct is
+	// encoded straight to JSON by user-facing handlers, so a marshalable hash
+	// leaks credentials. Requests carry passwords in their own payload types.
+	Password string `json:"-"`
 	// Role is the coarse authorization level for the user. It defaults to the
 	// generic "user" role at the database level so existing rows and new
 	// registrations are always assigned a role.

--- a/internal/database/models/users.go
+++ b/internal/database/models/users.go
@@ -9,4 +9,8 @@ type User struct {
 	Username string `json:"username"`
 	Email    string `json:"email" gorm:"uniqueIndex"`
 	Password string `json:"password"`
+	// Role is the coarse authorization level for the user. It defaults to the
+	// generic "user" role at the database level so existing rows and new
+	// registrations are always assigned a role.
+	Role string `json:"role" gorm:"index;default:user"`
 }

--- a/internal/server/authentication/constant.go
+++ b/internal/server/authentication/constant.go
@@ -1,12 +1,16 @@
 package authentication
 
 import (
+	"net/http"
 	"os"
 
 	"github.com/gorilla/sessions"
 )
 
 const SESSION_NAME = "session-name"
+
+// sessionMaxAge is the lifetime of the authenticated session cookie.
+const sessionMaxAge = 3600
 
 // devSessionKey is a non-secret, well-known signing key used ONLY outside of
 // production so local development and tests work without extra configuration.
@@ -16,7 +20,34 @@ const devSessionKey = "super-secret-32-byte-key-auth-v1"
 // store signs and encrypts the session cookies. Its key is resolved once at
 // package initialization: in production a missing SESSION_KEY is fatal (fail
 // closed), everywhere else a development fallback is used.
-var store = sessions.NewCookieStore([]byte(sessionKey()))
+var store = newSessionStore()
+
+// newSessionStore builds the cookie store with hardened defaults. gorilla's
+// out-of-the-box options are wrong for this app: HttpOnly is unset (leaving the
+// session cookie readable from JavaScript), SameSite is None, and Secure is
+// hard-coded true (so browsers drop the cookie over plain HTTP in development).
+// Setting them here means every save is safe by default — including the cookie
+// deletion performed by logout, which does not override the options.
+func newSessionStore() *sessions.CookieStore {
+	s := sessions.NewCookieStore([]byte(sessionKey()))
+	s.Options = sessionCookieOptions()
+	// Keep the signature lifetime in step with the cookie lifetime so a captured
+	// cookie cannot be replayed after it should have expired.
+	s.MaxAge(sessionMaxAge)
+	return s
+}
+
+// sessionCookieOptions returns the hardened cookie options used for every session
+// cookie this layer writes.
+func sessionCookieOptions() *sessions.Options {
+	return &sessions.Options{
+		Path:     "/",
+		MaxAge:   sessionMaxAge,
+		HttpOnly: true,
+		Secure:   SecureCookies(),
+		SameSite: http.SameSiteLaxMode,
+	}
+}
 
 // sessionKey resolves the cookie signing key. It sources SESSION_KEY from the
 // environment and fails closed in production when it is unset; outside production

--- a/internal/server/authentication/constant.go
+++ b/internal/server/authentication/constant.go
@@ -1,7 +1,47 @@
 package authentication
 
-import "github.com/gorilla/sessions"
+import (
+	"os"
+
+	"github.com/gorilla/sessions"
+)
 
 const SESSION_NAME = "session-name"
 
-var store = sessions.NewCookieStore([]byte("super-secret-32-byte-key-auth-v1"))
+// devSessionKey is a non-secret, well-known signing key used ONLY outside of
+// production so local development and tests work without extra configuration.
+// Production must supply its own key via SESSION_KEY.
+const devSessionKey = "super-secret-32-byte-key-auth-v1"
+
+// store signs and encrypts the session cookies. Its key is resolved once at
+// package initialization: in production a missing SESSION_KEY is fatal (fail
+// closed), everywhere else a development fallback is used.
+var store = sessions.NewCookieStore([]byte(sessionKey()))
+
+// sessionKey resolves the cookie signing key. It sources SESSION_KEY from the
+// environment and fails closed in production when it is unset; outside production
+// it falls back to a fixed development key so the app still boots.
+func sessionKey() string {
+	if key := os.Getenv("SESSION_KEY"); key != "" {
+		return key
+	}
+
+	if isProduction() {
+		panic("authentication: SESSION_KEY must be set when APP_ENV=production")
+	}
+
+	return devSessionKey
+}
+
+// isProduction reports whether the process is running in the production
+// environment, as declared by APP_ENV.
+func isProduction() bool {
+	return os.Getenv("APP_ENV") == "production"
+}
+
+// SecureCookies reports whether cookies set by this layer should carry the
+// Secure attribute (HTTPS-only). It is enabled in production and disabled
+// elsewhere so cookies still work over plain HTTP during local development.
+func SecureCookies() bool {
+	return isProduction()
+}

--- a/internal/server/authentication/csrf.go
+++ b/internal/server/authentication/csrf.go
@@ -1,0 +1,100 @@
+package authentication
+
+import (
+	"crypto/subtle"
+	"net/http"
+
+	"github.com/gorilla/sessions"
+)
+
+const (
+	// csrfSessionField is the key under which the CSRF token is stored in the
+	// session values.
+	csrfSessionField = "csrf_token"
+	// CSRFHeaderName is the request header carrying the CSRF token for AJAX/API
+	// style callers.
+	CSRFHeaderName = "X-CSRF-Token"
+	// CSRFFieldName is the form field carrying the CSRF token for HTML form
+	// submissions.
+	CSRFFieldName = "csrf_token"
+)
+
+// csrfSafeMethods are the HTTP methods considered safe (non-mutating); they are
+// never blocked by the CSRF middleware.
+var csrfSafeMethods = map[string]bool{
+	http.MethodGet:     true,
+	http.MethodHead:    true,
+	http.MethodOptions: true,
+	http.MethodTrace:   true,
+}
+
+// CSRFToken returns the CSRF token bound to the caller's session, reading the
+// existing token or creating one when absent. The token is created in the
+// session's (per-request cached) values; persistence to the cookie happens when
+// the session is saved — the CSRF middleware does this on safe requests so a
+// rendered form embeds a token that will later validate.
+func CSRFToken(r *http.Request) string {
+	session, _ := store.Get(r, SESSION_NAME)
+	if token, ok := session.Values[csrfSessionField].(string); ok && token != "" {
+		return token
+	}
+
+	token := SecureToken()
+	session.Values[csrfSessionField] = token
+	return token
+}
+
+// CSRF returns middleware that protects state-changing requests against
+// cross-site request forgery. Safe methods (GET/HEAD/OPTIONS/TRACE) pass through,
+// but first ensure a session-bound token exists and is persisted so forms and API
+// clients can obtain one. Unsafe methods (POST/PUT/PATCH/DELETE) must present a
+// token — via the X-CSRF-Token header or the csrf_token form field — that matches
+// the session token under a constant-time comparison, else they receive a 403.
+//
+// Login and registration are intentionally NOT wrapped by this middleware: they
+// precede the session that a CSRF token is bound to.
+func CSRF() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			session, _ := store.Get(r, SESSION_NAME)
+
+			expected, ok := session.Values[csrfSessionField].(string)
+			if !ok || expected == "" {
+				// Mint a token and persist it so the client can echo it back.
+				expected = SecureToken()
+				session.Values[csrfSessionField] = expected
+				session.Options = csrfCookieOptions()
+				_ = session.Save(r, w)
+			}
+
+			if csrfSafeMethods[r.Method] {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			presented := r.Header.Get(CSRFHeaderName)
+			if presented == "" {
+				presented = r.PostFormValue(CSRFFieldName)
+			}
+
+			if presented == "" || subtle.ConstantTimeCompare([]byte(presented), []byte(expected)) != 1 {
+				http.Error(w, "Forbidden - invalid CSRF token", http.StatusForbidden)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// csrfCookieOptions returns hardened cookie options used when the CSRF middleware
+// persists a freshly minted token to the session cookie.
+func csrfCookieOptions() *sessions.Options {
+	return &sessions.Options{
+		Path:     "/",
+		MaxAge:   3600,
+		HttpOnly: true,
+		Secure:   SecureCookies(),
+		SameSite: http.SameSiteLaxMode,
+	}
+}

--- a/internal/server/authentication/csrf.go
+++ b/internal/server/authentication/csrf.go
@@ -3,8 +3,6 @@ package authentication
 import (
 	"crypto/subtle"
 	"net/http"
-
-	"github.com/gorilla/sessions"
 )
 
 const (
@@ -63,7 +61,7 @@ func CSRF() func(http.Handler) http.Handler {
 				// Mint a token and persist it so the client can echo it back.
 				expected = SecureToken()
 				session.Values[csrfSessionField] = expected
-				session.Options = csrfCookieOptions()
+				session.Options = sessionCookieOptions()
 				_ = session.Save(r, w)
 			}
 
@@ -84,17 +82,5 @@ func CSRF() func(http.Handler) http.Handler {
 
 			next.ServeHTTP(w, r)
 		})
-	}
-}
-
-// csrfCookieOptions returns hardened cookie options used when the CSRF middleware
-// persists a freshly minted token to the session cookie.
-func csrfCookieOptions() *sessions.Options {
-	return &sessions.Options{
-		Path:     "/",
-		MaxAge:   3600,
-		HttpOnly: true,
-		Secure:   SecureCookies(),
-		SameSite: http.SameSiteLaxMode,
 	}
 }

--- a/internal/server/authentication/identity.go
+++ b/internal/server/authentication/identity.go
@@ -1,0 +1,28 @@
+package authentication
+
+import "context"
+
+// contextKey is an unexported type for context keys defined in this package. Using
+// a private type prevents collisions with keys defined in other packages.
+type contextKey string
+
+// identityContextKey is the context key under which the authenticated Identity is
+// stored by AuthMiddleware.
+const identityContextKey contextKey = "authentication.identity"
+
+// Identity is the authenticated principal for a request. It is derived from the
+// session (and re-validated against the database) by AuthMiddleware and injected
+// into the request context so downstream handlers can authorize without touching
+// the session store directly.
+type Identity struct {
+	UserID uint
+	Role   string
+}
+
+// CurrentUser returns the Identity that AuthMiddleware injected into ctx. The
+// boolean is false when the request is not authenticated (no middleware ran, or
+// authentication failed), in which case the zero Identity is returned.
+func CurrentUser(ctx context.Context) (Identity, bool) {
+	identity, ok := ctx.Value(identityContextKey).(Identity)
+	return identity, ok
+}

--- a/internal/server/authentication/login.go
+++ b/internal/server/authentication/login.go
@@ -77,6 +77,13 @@ func AuthLogin(ctx server_context.BackEndContext) http.HandlerFunc {
 		session.Values["authenticated"] = true
 		session.Values["id"] = user.ID
 
+		// Rotate the CSRF token across this privilege change. The pre-login token
+		// would otherwise carry into the authenticated session, so anyone who had
+		// planted or observed the visitor's earlier session cookie would hold a
+		// valid token for it. Dropping it makes the next protected request mint a
+		// fresh one.
+		delete(session.Values, csrfSessionField)
+
 		session.Options = sessionCookieOptions()
 
 		session.Save(r, w)

--- a/internal/server/authentication/login.go
+++ b/internal/server/authentication/login.go
@@ -10,7 +10,6 @@ import (
 	"github.com/erancihan/clair/internal/database/models"
 	server_context "github.com/erancihan/clair/internal/server/context"
 	"github.com/erancihan/clair/internal/web"
-	"github.com/gorilla/sessions"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 )
@@ -78,13 +77,7 @@ func AuthLogin(ctx server_context.BackEndContext) http.HandlerFunc {
 		session.Values["authenticated"] = true
 		session.Values["id"] = user.ID
 
-		session.Options = &sessions.Options{
-			Path:     "/",
-			MaxAge:   3600,
-			HttpOnly: true,
-			Secure:   SecureCookies(),
-			SameSite: http.SameSiteLaxMode,
-		}
+		session.Options = sessionCookieOptions()
 
 		session.Save(r, w)
 

--- a/internal/server/authentication/login.go
+++ b/internal/server/authentication/login.go
@@ -3,6 +3,8 @@ package authentication
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/a-h/templ"
 	"github.com/erancihan/clair/internal/database/models"
@@ -13,9 +15,13 @@ import (
 	"gorm.io/gorm"
 )
 
+// LoginPage renders the login form. It threads a validated `next` return path
+// from the query string into a hidden form field so a browser that was redirected
+// here by AuthMiddleware returns to where it started after signing in.
 func LoginPage(ctx server_context.BackEndContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		templ.Handler(web.Base("Clair", web.Login())).ServeHTTP(w, r)
+		next := safeNext(r.URL.Query().Get("next"), "")
+		templ.Handler(web.Base("Clair", web.Login(next))).ServeHTTP(w, r)
 	}
 }
 
@@ -24,16 +30,34 @@ type LoginPayload struct {
 	Password string `json:"password"`
 }
 
+// AuthLogin authenticates a user and establishes a session. It preserves the
+// existing JSON contract exactly — a JSON request (Content-Type: application/json)
+// still receives a bare 200 with the session cookie set — while additionally
+// supporting HTML form submissions, which are redirected to a validated `next`
+// path (falling back to /dashboard).
 func AuthLogin(ctx server_context.BackEndContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		isJSON := strings.Contains(r.Header.Get("Content-Type"), "application/json")
+
 		var creds LoginPayload
-		if err := json.NewDecoder(r.Body).Decode(&creds); err != nil {
-			http.Error(w, "Invalid request payload", http.StatusBadRequest)
-			return
+		var next string
+
+		if isJSON {
+			if err := json.NewDecoder(r.Body).Decode(&creds); err != nil {
+				http.Error(w, "Invalid request payload", http.StatusBadRequest)
+				return
+			}
+		} else {
+			if err := r.ParseForm(); err != nil {
+				http.Error(w, "Invalid request payload", http.StatusBadRequest)
+				return
+			}
+			creds.Email = r.PostFormValue("email")
+			creds.Password = r.PostFormValue("password")
+			next = r.PostFormValue("next")
 		}
 
 		// lookup user in database
-
 		tx := ctx.DBConn.Session(&gorm.Session{Context: r.Context()})
 
 		var user models.User
@@ -58,19 +82,43 @@ func AuthLogin(ctx server_context.BackEndContext) http.HandlerFunc {
 			Path:     "/",
 			MaxAge:   3600,
 			HttpOnly: true,
-			Secure:   false,
+			Secure:   SecureCookies(),
 			SameSite: http.SameSiteLaxMode,
 		}
 
 		session.Save(r, w)
 
-		// if the request is from API, return 200 OK
-		if r.Header.Get("Content-Type") == "application/json" {
+		// if the request is from API, return 200 OK (unchanged contract)
+		if isJSON {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
 
-		// else, redirect to dashboard
-		http.Redirect(w, r, "/dashboard", http.StatusFound)
+		// else, redirect to the validated return path (or the dashboard)
+		http.Redirect(w, r, safeNext(next, "/dashboard"), http.StatusFound)
 	}
+}
+
+// safeNext validates a post-login return path so it can only point back into this
+// application. It accepts same-origin absolute paths (a single leading slash) and
+// rejects everything else — empty values, protocol-relative "//host" URLs,
+// backslash tricks, and fully-qualified URLs — falling back to def.
+func safeNext(next, def string) string {
+	if next == "" {
+		return def
+	}
+
+	// Must be an absolute path, and must not be protocol-relative ("//host") or a
+	// backslash variant that some browsers normalise to "//".
+	if !strings.HasPrefix(next, "/") || strings.HasPrefix(next, "//") || strings.HasPrefix(next, "/\\") {
+		return def
+	}
+
+	// Reject anything that parses as (or carries) an absolute URL with a host.
+	u, err := url.Parse(next)
+	if err != nil || u.IsAbs() || u.Host != "" {
+		return def
+	}
+
+	return next
 }

--- a/internal/server/authentication/logout.go
+++ b/internal/server/authentication/logout.go
@@ -6,6 +6,10 @@ import (
 	server_context "github.com/erancihan/clair/internal/server/context"
 )
 
+// AuthLogout ends the authenticated session by expiring the session cookie. The
+// long-lived guest "sid" cookie is deliberately left intact so the visitor keeps
+// a stable guest identity (OwnerRef) after signing out — only the authentication
+// session ends here.
 func AuthLogout(ctx server_context.BackEndContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		session, _ := store.Get(r, SESSION_NAME)

--- a/internal/server/authentication/logout.go
+++ b/internal/server/authentication/logout.go
@@ -14,7 +14,13 @@ func AuthLogout(ctx server_context.BackEndContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		session, _ := store.Get(r, SESSION_NAME)
 
+		// Write the deletion cookie with the same hardened attributes the session
+		// was created with, resolved now rather than at package initialization.
+		// Attributes must line up for the browser to replace the cookie, and a
+		// Secure cookie would be dropped over plain HTTP outside production.
+		session.Options = sessionCookieOptions()
 		session.Options.MaxAge = -1
+
 		session.Save(r, w)
 	}
 }

--- a/internal/server/authentication/middleware.go
+++ b/internal/server/authentication/middleware.go
@@ -1,50 +1,112 @@
 package authentication
 
 import (
+	"context"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/erancihan/clair/internal/database/models"
 	server_context "github.com/erancihan/clair/internal/server/context"
 	"gorm.io/gorm"
 )
 
-// TODO:
-// - what are the best practices for session management, expiration, and security?
-// - enhance middleware to support roles/permissions
-
+// AuthMiddleware validates the session cookie, re-checks that the user still
+// exists in the database, and injects the resulting Identity into the request
+// context. On failure it delegates to unauthorized, which content-negotiates
+// between a 401 (JSON callers) and a redirect to the login page (browsers).
 func AuthMiddleware(ctx server_context.BackEndContext) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			session, err := store.Get(r, SESSION_NAME)
-			if err != nil {
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				return
-			}
-
-			auth, ok := session.Values["authenticated"].(bool)
-			if !ok || !auth {
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				return
-			}
-
-			// validate user exists
-			userID, ok := session.Values["id"].(uint)
+			identity, ok := authenticate(ctx, r)
 			if !ok {
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				unauthorized(w, r)
 				return
 			}
 
-			tx := ctx.DBConn.Session(&gorm.Session{Context: r.Context()})
-
-			var user models.User
-			result := tx.Limit(1).Where("id = ?", userID).Find(&user)
-			if result.RowsAffected == 0 {
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				return
-			}
-
-			// proceed to next handler
+			r = r.WithContext(context.WithValue(r.Context(), identityContextKey, identity))
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// AdminMiddleware wraps AuthMiddleware and additionally requires that the
+// authenticated user hold the admin role. Non-admin users receive a 403; the
+// authentication failure path (unauthenticated) is handled by AuthMiddleware and
+// stays content-negotiated.
+func AdminMiddleware(ctx server_context.BackEndContext) func(http.Handler) http.Handler {
+	requireAuth := AuthMiddleware(ctx)
+	return func(next http.Handler) http.Handler {
+		return requireAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			identity, ok := CurrentUser(r.Context())
+			if !ok {
+				// Should not happen: AuthMiddleware injects the identity before
+				// this handler runs. Treat a missing identity as unauthorized.
+				unauthorized(w, r)
+				return
+			}
+
+			if identity.Role != RoleAdmin {
+				http.Error(w, "Forbidden", http.StatusForbidden)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		}))
+	}
+}
+
+// authenticate resolves the Identity for a request from the session cookie,
+// re-validating the user against the database. It returns false when the caller
+// is unauthenticated or the backing user row no longer exists.
+func authenticate(ctx server_context.BackEndContext, r *http.Request) (Identity, bool) {
+	session, err := store.Get(r, SESSION_NAME)
+	if err != nil {
+		return Identity{}, false
+	}
+
+	if auth, ok := session.Values["authenticated"].(bool); !ok || !auth {
+		return Identity{}, false
+	}
+
+	userID, ok := session.Values["id"].(uint)
+	if !ok {
+		return Identity{}, false
+	}
+
+	tx := ctx.DBConn.Session(&gorm.Session{Context: r.Context()})
+
+	var user models.User
+	result := tx.Limit(1).Where("id = ?", userID).Find(&user)
+	if result.RowsAffected == 0 {
+		return Identity{}, false
+	}
+
+	role := user.Role
+	if role == "" {
+		role = RoleUser
+	}
+
+	return Identity{UserID: user.ID, Role: role}, true
+}
+
+// unauthorized responds to an authentication failure using content negotiation.
+// API/JSON callers receive a 401 so they can react programmatically; browsers are
+// redirected to the login page with a validated return path so they can sign in
+// and come back to where they were.
+func unauthorized(w http.ResponseWriter, r *http.Request) {
+	if wantsJSON(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	next := url.QueryEscape(r.URL.RequestURI())
+	http.Redirect(w, r, "/login?next="+next, http.StatusFound)
+}
+
+// wantsJSON reports whether the caller is a JSON/API client, as signalled by an
+// Accept or Content-Type header mentioning application/json.
+func wantsJSON(r *http.Request) bool {
+	return strings.Contains(r.Header.Get("Accept"), "application/json") ||
+		strings.Contains(r.Header.Get("Content-Type"), "application/json")
 }

--- a/internal/server/authentication/roles.go
+++ b/internal/server/authentication/roles.go
@@ -1,0 +1,12 @@
+package authentication
+
+// Roles are intentionally modeled as plain strings rather than a closed enum:
+// this is a central authentication layer shared by multiple domains (a shop CMS,
+// a booking domain, future admin surfaces), so keeping the type open leaves
+// headroom to introduce finer-grained roles later without a breaking change.
+const (
+	// RoleUser is the default role granted to every registered account.
+	RoleUser = "user"
+	// RoleAdmin grants access to administrative surfaces.
+	RoleAdmin = "admin"
+)

--- a/internal/server/authentication/session.go
+++ b/internal/server/authentication/session.go
@@ -34,6 +34,11 @@ func SecureToken() string {
 // on the response as an HttpOnly, site-wide, Lax cookie. This id is stable for a
 // browser regardless of whether the user is authenticated, which is what lets the
 // booking domain attribute anonymous activity to a consistent owner.
+//
+// It is idempotent within a request: a freshly minted id is mirrored onto the
+// request so repeat calls return the same value and only one "sid" cookie is ever
+// set per response. Handlers that resolve an owner more than once (for example
+// reading a hold and then writing an order) therefore see one consistent id.
 func SessionID(w http.ResponseWriter, r *http.Request) string {
 	if cookie, err := r.Cookie(sessionIDCookieName); err == nil && cookie.Value != "" {
 		return cookie.Value
@@ -49,6 +54,11 @@ func SessionID(w http.ResponseWriter, r *http.Request) string {
 		Secure:   SecureCookies(),
 		SameSite: http.SameSiteLaxMode,
 	})
+
+	// Mirror the new id onto the request so later calls in this same request read
+	// it back instead of minting (and setting) a second, conflicting id.
+	r.AddCookie(&http.Cookie{Name: sessionIDCookieName, Value: sid})
+
 	return sid
 }
 
@@ -56,6 +66,11 @@ func SessionID(w http.ResponseWriter, r *http.Request) string {
 // callers get "user:<id>"; everyone else gets "guest:<sid>", minting the guest
 // session cookie if needed. This exact on-disk format is persisted by downstream
 // domains (e.g. booking holds and orders), so it must remain stable.
+//
+// "Authenticated" here means an Identity is present in the request context, which
+// AuthMiddleware injects. On a route that is NOT behind AuthMiddleware a signed-in
+// visitor is indistinguishable from a guest and will get "guest:<sid>", so any
+// route whose ownership should follow the account must run behind it.
 func OwnerRef(w http.ResponseWriter, r *http.Request) string {
 	if identity, ok := CurrentUser(r.Context()); ok {
 		return fmt.Sprintf("user:%d", identity.UserID)

--- a/internal/server/authentication/session.go
+++ b/internal/server/authentication/session.go
@@ -1,0 +1,64 @@
+package authentication
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+)
+
+const (
+	// sessionIDCookieName is the name of the long-lived guest session cookie.
+	sessionIDCookieName = "sid"
+	// sessionIDMaxAge is the lifetime of the guest session cookie (~1 year). The
+	// guest identity is meant to outlive individual auth sessions so a visitor
+	// keeps the same owner reference across visits.
+	sessionIDMaxAge = 60 * 60 * 24 * 365
+	// tokenBytes is the entropy, in bytes, of tokens minted by SecureToken.
+	tokenBytes = 32 // 256 bits
+)
+
+// SecureToken returns a cryptographically-random, URL-safe token carrying 256
+// bits of entropy. It is used for session ids and CSRF tokens. It panics only if
+// the system CSPRNG fails, which is not a recoverable condition.
+func SecureToken() string {
+	b := make([]byte, tokenBytes)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("authentication: failed to read from CSPRNG: %v", err))
+	}
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+// SessionID returns the caller's long-lived guest session id, reading it from the
+// "sid" cookie. When the cookie is absent (or empty) a new id is minted and set
+// on the response as an HttpOnly, site-wide, Lax cookie. This id is stable for a
+// browser regardless of whether the user is authenticated, which is what lets the
+// booking domain attribute anonymous activity to a consistent owner.
+func SessionID(w http.ResponseWriter, r *http.Request) string {
+	if cookie, err := r.Cookie(sessionIDCookieName); err == nil && cookie.Value != "" {
+		return cookie.Value
+	}
+
+	sid := SecureToken()
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionIDCookieName,
+		Value:    sid,
+		Path:     "/",
+		MaxAge:   sessionIDMaxAge,
+		HttpOnly: true,
+		Secure:   SecureCookies(),
+		SameSite: http.SameSiteLaxMode,
+	})
+	return sid
+}
+
+// OwnerRef returns a stable owner reference for the current caller. Authenticated
+// callers get "user:<id>"; everyone else gets "guest:<sid>", minting the guest
+// session cookie if needed. This exact on-disk format is persisted by downstream
+// domains (e.g. booking holds and orders), so it must remain stable.
+func OwnerRef(w http.ResponseWriter, r *http.Request) string {
+	if identity, ok := CurrentUser(r.Context()); ok {
+		return fmt.Sprintf("user:%d", identity.UserID)
+	}
+	return "guest:" + SessionID(w, r)
+}

--- a/internal/server/authentication/webhook.go
+++ b/internal/server/authentication/webhook.go
@@ -1,0 +1,33 @@
+package authentication
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// VerifyProviderSignature reports whether sigHeader is a valid HMAC-SHA256
+// signature of the raw request body using the shared secret. The comparison is
+// constant-time (hmac.Equal). The header may be a bare hex digest or carry a
+// "sha256=" prefix, matching the convention used by several webhook providers.
+//
+// This is only the verifier; wiring it to a concrete webhook handler belongs to
+// the domain that owns that webhook (e.g. the booking/payment domain), not to
+// this shared authentication layer.
+func VerifyProviderSignature(secret, body []byte, sigHeader string) bool {
+	if len(secret) == 0 || sigHeader == "" {
+		return false
+	}
+
+	provided, err := hex.DecodeString(strings.TrimPrefix(sigHeader, "sha256="))
+	if err != nil {
+		return false
+	}
+
+	mac := hmac.New(sha256.New, secret)
+	mac.Write(body)
+	expected := mac.Sum(nil)
+
+	return hmac.Equal(provided, expected)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -92,15 +92,19 @@ func (s *backend) Routes() http.Handler {
 				auth.HandleFunc("GET /logout", api_auth.AuthLogout(s.context))
 			})
 
+			// Listing every account is an administrative capability, so this group
+			// runs behind AdminMiddleware rather than being publicly readable.
 			v1.Group("users", func(users *router.Router) {
 				users.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
 					// return JSON response with all users
 
-					// get all users from the database
+					// get all users from the database. Credentials are never needed
+					// here, so they are left in the database rather than loaded and
+					// relied upon not to serialize.
 					var users []models.User
 
 					tx := s.context.DBConn.Session(&gorm.Session{Context: r.Context()})
-					tx.Find(&users)
+					tx.Omit("password").Find(&users)
 
 					// return JSON response
 					w.Header().Set("Content-Type", "application/json")
@@ -108,7 +112,7 @@ func (s *backend) Routes() http.Handler {
 
 					json.NewEncoder(w).Encode(users)
 				})
-			})
+			}, api_auth.AdminMiddleware(s.context))
 		})
 	})
 

--- a/internal/web/index.go
+++ b/internal/web/index.go
@@ -14,8 +14,8 @@ func Home() templ.Component {
 	return pages.Home()
 }
 
-func Login() templ.Component {
-	return pages.LoginPage()
+func Login(next string) templ.Component {
+	return pages.LoginPage(next)
 }
 
 func NotFound() templ.Component {

--- a/internal/web/pages/login.templ
+++ b/internal/web/pages/login.templ
@@ -8,7 +8,7 @@ package pages
 //   <body class="h-full">
 //   ```
 // -->
-templ LoginPage() {
+templ LoginPage(next string) {
 <div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
     <div class="sm:mx-auto sm:w-full sm:max-w-sm">
         <img class="mx-auto h-10 w-auto"
@@ -18,6 +18,9 @@ templ LoginPage() {
 
     <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
         <form class="space-y-6" action="/api/v1/auth/login" method="POST">
+            if next != "" {
+                <input type="hidden" name="next" value={ next } />
+            }
             <div>
                 <label for="email" class="block text-sm/6 font-medium text-gray-900">Email address</label>
                 <div class="mt-2">

--- a/test/auth_cookie_test.go
+++ b/test/auth_cookie_test.go
@@ -1,0 +1,106 @@
+package test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	authentication "github.com/erancihan/clair/internal/server/authentication"
+	server_context "github.com/erancihan/clair/internal/server/context"
+)
+
+// findCookie returns the named cookie from a response, or nil.
+func findCookie(resp *http.Response, name string) *http.Cookie {
+	for _, c := range resp.Cookies() {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}
+
+// TestSessionCookieHardening verifies the attributes of the session cookie that
+// logout writes. Logout does not override the store's options, so this is what
+// catches an unsafe default leaking through: the cookie must always be HttpOnly
+// and SameSite=Lax, and must only carry Secure in production (a Secure cookie is
+// dropped by browsers over plain HTTP, which would silently break logout in
+// development).
+func TestSessionCookieHardening(t *testing.T) {
+	tests := []struct {
+		name       string
+		appEnv     string
+		wantSecure bool
+	}{
+		{name: "development", appEnv: "development", wantSecure: false},
+		{name: "production", appEnv: "production", wantSecure: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("APP_ENV", tc.appEnv)
+
+			rec := httptest.NewRecorder()
+			authentication.AuthLogout(server_context.BackEndContext{}).ServeHTTP(
+				rec, httptest.NewRequest(http.MethodGet, "/logout", nil))
+
+			cookie := findCookie(rec.Result(), "session-name")
+			if cookie == nil {
+				t.Fatal("expected logout to write the session cookie")
+			}
+
+			if !cookie.HttpOnly {
+				t.Error("session cookie must be HttpOnly")
+			}
+			if cookie.SameSite != http.SameSiteLaxMode {
+				t.Errorf("session cookie SameSite = %v, want Lax", cookie.SameSite)
+			}
+			if cookie.Path != "/" {
+				t.Errorf("session cookie Path = %q, want \"/\"", cookie.Path)
+			}
+			if cookie.Secure != tc.wantSecure {
+				t.Errorf("session cookie Secure = %v, want %v (APP_ENV=%s)",
+					cookie.Secure, tc.wantSecure, tc.appEnv)
+			}
+			// Logout must expire the cookie.
+			if cookie.MaxAge >= 0 {
+				t.Errorf("logout should expire the session cookie, got MaxAge=%d", cookie.MaxAge)
+			}
+		})
+	}
+}
+
+// TestGuestCookieHardening verifies the guest "sid" cookie carries Secure only in
+// production, mirroring the session cookie policy.
+func TestGuestCookieHardening(t *testing.T) {
+	tests := []struct {
+		name       string
+		appEnv     string
+		wantSecure bool
+	}{
+		{name: "development", appEnv: "development", wantSecure: false},
+		{name: "production", appEnv: "production", wantSecure: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("APP_ENV", tc.appEnv)
+
+			rec := httptest.NewRecorder()
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				authentication.SessionID(w, r)
+			}).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+			cookie := findCookie(rec.Result(), "sid")
+			if cookie == nil {
+				t.Fatal("expected a sid cookie to be minted")
+			}
+			if !cookie.HttpOnly {
+				t.Error("sid cookie must be HttpOnly")
+			}
+			if cookie.Secure != tc.wantSecure {
+				t.Errorf("sid cookie Secure = %v, want %v (APP_ENV=%s)",
+					cookie.Secure, tc.wantSecure, tc.appEnv)
+			}
+		})
+	}
+}

--- a/test/auth_csrf_test.go
+++ b/test/auth_csrf_test.go
@@ -1,0 +1,151 @@
+package test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	authentication "github.com/erancihan/clair/internal/server/authentication"
+)
+
+// newCSRFTestServer mounts a CSRF-protected mux:
+//
+//	GET  /token  -> returns the session-bound CSRF token (and sets the session cookie)
+//	POST /submit -> returns "ok" when the CSRF check passes
+func newCSRFTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	protect := authentication.CSRF()
+	mux := http.NewServeMux()
+
+	mux.Handle("GET /token", protect(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(authentication.CSRFToken(r)))
+	})))
+	mux.Handle("POST /submit", protect(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})))
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// fetchCSRFToken performs the GET /token handshake and returns the token together
+// with the cookies that bind it to a session.
+func fetchCSRFToken(t *testing.T, srv *httptest.Server) (string, []*http.Cookie) {
+	t.Helper()
+
+	resp, err := http.Get(srv.URL + "/token")
+	if err != nil {
+		t.Fatalf("token request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from GET /token, got %d", resp.StatusCode)
+	}
+
+	token := readBody(t, resp)
+	if token == "" {
+		t.Fatal("expected a non-empty CSRF token")
+	}
+
+	cookies := resp.Cookies()
+	if len(cookies) == 0 {
+		t.Fatal("expected GET /token to set a session cookie")
+	}
+	return token, cookies
+}
+
+func TestCSRF(t *testing.T) {
+	srv := newCSRFTestServer(t)
+	token, cookies := fetchCSRFToken(t, srv)
+
+	newPost := func(body string, contentType string) *http.Request {
+		var r *http.Request
+		if body != "" {
+			r, _ = http.NewRequest(http.MethodPost, srv.URL+"/submit", strings.NewReader(body))
+			r.Header.Set("Content-Type", contentType)
+		} else {
+			r, _ = http.NewRequest(http.MethodPost, srv.URL+"/submit", nil)
+		}
+		for _, c := range cookies {
+			r.AddCookie(c)
+		}
+		return r
+	}
+
+	t.Run("mutating request with matching header token passes", func(t *testing.T) {
+		req := newPost("", "")
+		req.Header.Set(authentication.CSRFHeaderName, token)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("submit failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200 with valid header token, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("mutating request with matching form token passes", func(t *testing.T) {
+		form := url.Values{authentication.CSRFFieldName: {token}}
+		req := newPost(form.Encode(), "application/x-www-form-urlencoded")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("submit failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200 with valid form token, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("tokenless mutating request is rejected", func(t *testing.T) {
+		req := newPost("", "")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("submit failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("expected 403 without a token, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("mutating request with wrong token is rejected", func(t *testing.T) {
+		req := newPost("", "")
+		req.Header.Set(authentication.CSRFHeaderName, token+"tampered")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("submit failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("expected 403 with a wrong token, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("safe GET method passes through", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/token")
+		if err != nil {
+			t.Fatalf("GET failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected GET to pass through with 200, got %d", resp.StatusCode)
+		}
+	})
+}

--- a/test/auth_hardening_test.go
+++ b/test/auth_hardening_test.go
@@ -1,0 +1,115 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/erancihan/clair/internal/database/models"
+	authentication "github.com/erancihan/clair/internal/server/authentication"
+)
+
+// TestUserJSONNeverExposesPassword guards the credential-leak fix. models.User is
+// encoded straight to JSON by user-facing handlers (e.g. GET /api/v1/users), so
+// the bcrypt hash must never be marshalable — regardless of which handler does
+// the encoding.
+func TestUserJSONNeverExposesPassword(t *testing.T) {
+	user := models.User{
+		ID:       7,
+		Username: "leak-check",
+		Email:    "leak@example.com",
+		Password: "$2a$10$bcrypthashthatmustnotescape",
+		Role:     authentication.RoleAdmin,
+	}
+
+	encoded, err := json.Marshal(user)
+	if err != nil {
+		t.Fatalf("failed to marshal user: %v", err)
+	}
+	payload := string(encoded)
+
+	if strings.Contains(payload, user.Password) {
+		t.Errorf("serialized user leaks the password hash: %s", payload)
+	}
+	if strings.Contains(strings.ToLower(payload), "\"password\"") {
+		t.Errorf("serialized user still carries a password field: %s", payload)
+	}
+
+	// The rest of the record must still round-trip for legitimate consumers.
+	for _, want := range []string{"leak-check", "leak@example.com", authentication.RoleAdmin} {
+		if !strings.Contains(payload, want) {
+			t.Errorf("serialized user is missing %q: %s", want, payload)
+		}
+	}
+}
+
+// TestCSRFTokenRotatesOnLogin verifies that a CSRF token obtained before signing
+// in does not survive into the authenticated session. Without rotation, anyone
+// who had planted or observed the visitor's pre-login session cookie would hold a
+// valid token for their authenticated session, defeating CSRF protection exactly
+// where it matters.
+func TestCSRFTokenRotatesOnLogin(t *testing.T) {
+	srv := newAuthTestServer(t)
+	createUser(t, srv.db, "rotate@example.com", "rotate-pass-123", authentication.RoleUser)
+
+	client := noRedirectClient()
+
+	// 1. Before logging in, obtain a CSRF token bound to the current session.
+	resp, err := client.Get(srv.URL + "/csrf")
+	if err != nil {
+		t.Fatalf("pre-login csrf request failed: %v", err)
+	}
+	before := readBody(t, resp)
+	resp.Body.Close()
+	preLoginCookies := resp.Cookies()
+
+	if before == "" {
+		t.Fatal("expected a pre-login CSRF token")
+	}
+
+	// 2. Log in while carrying that same session cookie.
+	body, _ := json.Marshal(map[string]string{
+		"email":    "rotate@example.com",
+		"password": "rotate-pass-123",
+	})
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	for _, c := range preLoginCookies {
+		req.AddCookie(c)
+	}
+
+	loginResp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("login failed: %v", err)
+	}
+	loginResp.Body.Close()
+	if loginResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected login 200, got %d", loginResp.StatusCode)
+	}
+
+	sessionCookies := loginResp.Cookies()
+	if len(sessionCookies) == 0 {
+		sessionCookies = preLoginCookies
+	}
+
+	// 3. Read the token again on the now-authenticated session.
+	req2, _ := http.NewRequest(http.MethodGet, srv.URL+"/csrf", nil)
+	for _, c := range sessionCookies {
+		req2.AddCookie(c)
+	}
+	resp2, err := client.Do(req2)
+	if err != nil {
+		t.Fatalf("post-login csrf request failed: %v", err)
+	}
+	after := readBody(t, resp2)
+	resp2.Body.Close()
+
+	if after == "" {
+		t.Fatal("expected a post-login CSRF token")
+	}
+	if before == after {
+		t.Error("CSRF token survived the login boundary; it must rotate on privilege change")
+	}
+}

--- a/test/auth_helpers_test.go
+++ b/test/auth_helpers_test.go
@@ -117,6 +117,13 @@ func newAuthTestServer(t *testing.T) *authTestServer {
 		_, _ = w.Write([]byte(authentication.OwnerRef(w, r)))
 	})
 
+	// Shares the session store with /login, so tests can observe how the CSRF
+	// token behaves across an authentication boundary.
+	mux.Handle("GET /csrf", authentication.CSRF()(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(authentication.CSRFToken(r)))
+		})))
+
 	mux.Handle("GET /owner-auth", authentication.AuthMiddleware(ctx)(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write([]byte(authentication.OwnerRef(w, r)))

--- a/test/auth_helpers_test.go
+++ b/test/auth_helpers_test.go
@@ -1,0 +1,157 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/erancihan/clair/internal/database/models"
+	authentication "github.com/erancihan/clair/internal/server/authentication"
+	server_context "github.com/erancihan/clair/internal/server/context"
+	"go.uber.org/zap"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// newAuthTestDB opens a gorm connection to the test Postgres database and resets
+// the users table (drop + AutoMigrate) so each auth test starts from a clean
+// schema that includes the Role column.
+func newAuthTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		dsn = defaultTestDatabaseURL
+	}
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect to test database at %s: %v", dsn, err)
+	}
+
+	if err := db.Migrator().DropTable(&models.User{}); err != nil {
+		t.Fatalf("failed to drop users table: %v", err)
+	}
+	if err := db.AutoMigrate(&models.User{}); err != nil {
+		t.Fatalf("failed to migrate users table: %v", err)
+	}
+
+	return db
+}
+
+// newAuthTestContext builds a BackEndContext backed by the test database and a
+// no-op logger, suitable for constructing the authentication middleware/handlers
+// directly in a test.
+func newAuthTestContext(t *testing.T) server_context.BackEndContext {
+	t.Helper()
+	return server_context.BackEndContext{
+		DBConn: newAuthTestDB(t),
+		Logger: zap.NewNop(),
+	}
+}
+
+// createUser inserts a user with the given email, password (bcrypt-hashed) and
+// role, returning the created row. An empty role lets the database default apply.
+func createUser(t *testing.T, db *gorm.DB, email, password, role string) models.User {
+	t.Helper()
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("failed to hash password: %v", err)
+	}
+
+	user := models.User{Email: email, Password: string(hash), Role: role}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+	return user
+}
+
+// authTestServer bundles an httptest.Server that mounts the authentication layer
+// (login + a few guarded/echo routes) against a shared context, along with the
+// database handle so tests can manipulate rows directly.
+type authTestServer struct {
+	*httptest.Server
+	ctx server_context.BackEndContext
+	db  *gorm.DB
+}
+
+// newAuthTestServer wires up a self-contained httptest server exercising the auth
+// layer:
+//
+//	POST /login   -> AuthLogin (JSON + form)
+//	GET  /whoami  -> behind AuthMiddleware; echoes CurrentUser as JSON
+//	GET  /admin   -> behind AdminMiddleware; echoes "ok"
+//	GET  /owner   -> echoes OwnerRef (guest identity path)
+//	GET  /owner-auth -> behind AuthMiddleware; echoes OwnerRef (user path)
+func newAuthTestServer(t *testing.T) *authTestServer {
+	t.Helper()
+
+	ctx := newAuthTestContext(t)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /login", authentication.AuthLogin(ctx))
+	mux.HandleFunc("GET /login-page", authentication.LoginPage(ctx))
+
+	mux.Handle("GET /whoami", authentication.AuthMiddleware(ctx)(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			identity, _ := authentication.CurrentUser(r.Context())
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"user_id": identity.UserID,
+				"role":    identity.Role,
+			})
+		})))
+
+	mux.Handle("GET /admin", authentication.AdminMiddleware(ctx)(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		})))
+
+	mux.HandleFunc("GET /owner", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(authentication.OwnerRef(w, r)))
+	})
+
+	mux.Handle("GET /owner-auth", authentication.AuthMiddleware(ctx)(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(authentication.OwnerRef(w, r)))
+		})))
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return &authTestServer{Server: srv, ctx: ctx, db: ctx.DBConn}
+}
+
+// loginJSON performs a JSON login against the test server and returns the session
+// cookies set on success.
+func loginJSON(t *testing.T, srv *authTestServer, email, password string) []*http.Cookie {
+	t.Helper()
+
+	body, _ := json.Marshal(map[string]string{"email": email, "password": password})
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Do not follow redirects; capture the raw response.
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("login request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected login 200, got %d", resp.StatusCode)
+	}
+
+	cookies := resp.Cookies()
+	if len(cookies) == 0 {
+		t.Fatal("login did not set any cookies")
+	}
+	return cookies
+}

--- a/test/auth_identity_test.go
+++ b/test/auth_identity_test.go
@@ -1,0 +1,161 @@
+package test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	authentication "github.com/erancihan/clair/internal/server/authentication"
+)
+
+// noRedirectClient returns an http.Client that captures redirects instead of
+// following them, so tests can assert on 302 responses.
+func noRedirectClient() *http.Client {
+	return &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+// TestLoginInjectsIdentity verifies that after a successful login a handler
+// behind AuthMiddleware reads the correct Identity via CurrentUser.
+func TestLoginInjectsIdentity(t *testing.T) {
+	srv := newAuthTestServer(t)
+	user := createUser(t, srv.db, "identity@example.com", "s3cret-pass", authentication.RoleUser)
+
+	cookies := loginJSON(t, srv, "identity@example.com", "s3cret-pass")
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/whoami", nil)
+	req.Header.Set("Accept", "application/json")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("whoami request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body struct {
+		UserID uint   `json:"user_id"`
+		Role   string `json:"role"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode whoami: %v", err)
+	}
+
+	if body.UserID != user.ID {
+		t.Errorf("expected user id %d, got %d", user.ID, body.UserID)
+	}
+	if body.Role != authentication.RoleUser {
+		t.Errorf("expected role %q, got %q", authentication.RoleUser, body.Role)
+	}
+}
+
+// TestAdminMiddleware is a table-driven test of the AdminMiddleware's outcomes.
+func TestAdminMiddleware(t *testing.T) {
+	srv := newAuthTestServer(t)
+	createUser(t, srv.db, "admin@example.com", "admin-pass-123", authentication.RoleAdmin)
+	createUser(t, srv.db, "user@example.com", "user-pass-123", authentication.RoleUser)
+
+	adminCookies := loginJSON(t, srv, "admin@example.com", "admin-pass-123")
+	userCookies := loginJSON(t, srv, "user@example.com", "user-pass-123")
+
+	tests := []struct {
+		name       string
+		cookies    []*http.Cookie
+		accept     string
+		wantStatus int
+		wantLoc    string // substring expected in Location header (302 only)
+	}{
+		{
+			name:       "admin passes",
+			cookies:    adminCookies,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "regular user forbidden",
+			cookies:    userCookies,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "unauthenticated browser redirects to login",
+			cookies:    nil,
+			accept:     "text/html",
+			wantStatus: http.StatusFound,
+			wantLoc:    "/login?next=",
+		},
+		{
+			name:       "unauthenticated JSON caller gets 401",
+			cookies:    nil,
+			accept:     "application/json",
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodGet, srv.URL+"/admin", nil)
+			if tc.accept != "" {
+				req.Header.Set("Accept", tc.accept)
+			}
+			for _, c := range tc.cookies {
+				req.AddCookie(c)
+			}
+
+			resp, err := noRedirectClient().Do(req)
+			if err != nil {
+				t.Fatalf("admin request failed: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatus {
+				t.Fatalf("expected status %d, got %d", tc.wantStatus, resp.StatusCode)
+			}
+
+			if tc.wantLoc != "" {
+				loc := resp.Header.Get("Location")
+				if !strings.Contains(loc, tc.wantLoc) {
+					t.Errorf("expected Location to contain %q, got %q", tc.wantLoc, loc)
+				}
+			}
+		})
+	}
+}
+
+// TestAuthMiddlewareDeletedUser verifies that a valid session cookie whose backing
+// user row has been deleted is treated as unauthorized.
+func TestAuthMiddlewareDeletedUser(t *testing.T) {
+	srv := newAuthTestServer(t)
+	user := createUser(t, srv.db, "ghost@example.com", "ghost-pass-123", authentication.RoleUser)
+
+	cookies := loginJSON(t, srv, "ghost@example.com", "ghost-pass-123")
+
+	// Hard-delete the user row so the session id no longer resolves.
+	if err := srv.db.Unscoped().Delete(&user).Error; err != nil {
+		t.Fatalf("failed to delete user: %v", err)
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/whoami", nil)
+	req.Header.Set("Accept", "application/json")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+
+	resp, err := noRedirectClient().Do(req)
+	if err != nil {
+		t.Fatalf("whoami request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401 for deleted user, got %d", resp.StatusCode)
+	}
+}

--- a/test/auth_login_test.go
+++ b/test/auth_login_test.go
@@ -1,0 +1,104 @@
+package test
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	authentication "github.com/erancihan/clair/internal/server/authentication"
+)
+
+// TestLoginJSONContractPreserved verifies the existing JSON login contract: a
+// JSON request receives a bare 200 with a session cookie and no redirect.
+func TestLoginJSONContractPreserved(t *testing.T) {
+	srv := newAuthTestServer(t)
+	createUser(t, srv.db, "json@example.com", "json-pass-123", authentication.RoleUser)
+
+	cookies := loginJSON(t, srv, "json@example.com", "json-pass-123")
+	if len(cookies) == 0 {
+		t.Fatal("expected JSON login to set a session cookie")
+	}
+}
+
+// TestLoginFormRedirect exercises the browser (form) login path and the safeNext
+// return-path validation.
+func TestLoginFormRedirect(t *testing.T) {
+	srv := newAuthTestServer(t)
+	createUser(t, srv.db, "form@example.com", "form-pass-123", authentication.RoleUser)
+
+	tests := []struct {
+		name    string
+		next    string
+		wantLoc string
+	}{
+		{name: "no next falls back to dashboard", next: "", wantLoc: "/dashboard"},
+		{name: "valid same-origin path is honored", next: "/account/orders", wantLoc: "/account/orders"},
+		{name: "protocol-relative url is rejected", next: "//evil.example.com", wantLoc: "/dashboard"},
+		{name: "absolute url is rejected", next: "http://evil.example.com/x", wantLoc: "/dashboard"},
+		{name: "backslash trick is rejected", next: "/\\evil.example.com", wantLoc: "/dashboard"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			form := url.Values{
+				"email":    {"form@example.com"},
+				"password": {"form-pass-123"},
+			}
+			if tc.next != "" {
+				form.Set("next", tc.next)
+			}
+
+			req, _ := http.NewRequest(http.MethodPost, srv.URL+"/login", strings.NewReader(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+			resp, err := noRedirectClient().Do(req)
+			if err != nil {
+				t.Fatalf("form login failed: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusFound {
+				t.Fatalf("expected 302 redirect, got %d", resp.StatusCode)
+			}
+			if loc := resp.Header.Get("Location"); loc != tc.wantLoc {
+				t.Errorf("expected redirect to %q, got %q", tc.wantLoc, loc)
+			}
+		})
+	}
+}
+
+// TestLoginPageRendersNext verifies the login page renders a validated `next`
+// value into a hidden field, and drops it when the value is unsafe.
+func TestLoginPageRendersNext(t *testing.T) {
+	srv := newAuthTestServer(t)
+
+	t.Run("safe next is rendered", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/login-page?next=" + url.QueryEscape("/account"))
+		if err != nil {
+			t.Fatalf("login page request failed: %v", err)
+		}
+		defer resp.Body.Close()
+		body := readBody(t, resp)
+
+		if !strings.Contains(body, `name="next"`) {
+			t.Errorf("expected a hidden next field in the login page, got:\n%s", body)
+		}
+		if !strings.Contains(body, `value="/account"`) {
+			t.Errorf("expected the next value to be rendered, got:\n%s", body)
+		}
+	})
+
+	t.Run("unsafe next is dropped", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/login-page?next=" + url.QueryEscape("//evil.example.com"))
+		if err != nil {
+			t.Fatalf("login page request failed: %v", err)
+		}
+		defer resp.Body.Close()
+		body := readBody(t, resp)
+
+		if strings.Contains(body, `name="next"`) {
+			t.Errorf("expected no next field for an unsafe value, got:\n%s", body)
+		}
+	})
+}

--- a/test/auth_session_test.go
+++ b/test/auth_session_test.go
@@ -1,0 +1,130 @@
+package test
+
+import (
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"testing"
+
+	authentication "github.com/erancihan/clair/internal/server/authentication"
+)
+
+// sidCookie returns the "sid" cookie from a response, or nil if absent.
+func sidCookie(resp *http.Response) *http.Cookie {
+	for _, c := range resp.Cookies() {
+		if c.Name == "sid" {
+			return c
+		}
+	}
+	return nil
+}
+
+func readBody(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+	return string(b)
+}
+
+// TestSessionIDMintAndReuse verifies that the first guest request mints a
+// long-lived, HttpOnly, site-wide "sid" cookie and that a subsequent request
+// carrying that cookie reuses it (no new mint), with OwnerRef returning
+// "guest:<sid>".
+func TestSessionIDMintAndReuse(t *testing.T) {
+	srv := newAuthTestServer(t)
+
+	// First request: no sid cookie -> a fresh one is minted.
+	resp1, err := noRedirectClient().Get(srv.URL + "/owner")
+	if err != nil {
+		t.Fatalf("owner request failed: %v", err)
+	}
+	body1 := readBody(t, resp1)
+	resp1.Body.Close()
+
+	sid := sidCookie(resp1)
+	if sid == nil {
+		t.Fatal("expected first response to set a sid cookie")
+	}
+	if !sid.HttpOnly {
+		t.Error("sid cookie should be HttpOnly")
+	}
+	if sid.Path != "/" {
+		t.Errorf("sid cookie Path should be \"/\", got %q", sid.Path)
+	}
+	if sid.MaxAge <= 0 {
+		t.Errorf("sid cookie should be long-lived (positive MaxAge), got %d", sid.MaxAge)
+	}
+	if want := "guest:" + sid.Value; body1 != want {
+		t.Errorf("expected OwnerRef %q, got %q", want, body1)
+	}
+
+	// Second request: carry the sid cookie -> it is reused, not re-minted.
+	req2, _ := http.NewRequest(http.MethodGet, srv.URL+"/owner", nil)
+	req2.AddCookie(&http.Cookie{Name: "sid", Value: sid.Value})
+	resp2, err := noRedirectClient().Do(req2)
+	if err != nil {
+		t.Fatalf("second owner request failed: %v", err)
+	}
+	body2 := readBody(t, resp2)
+	resp2.Body.Close()
+
+	if got := sidCookie(resp2); got != nil {
+		t.Errorf("expected no new sid cookie on reuse, got %q", got.Value)
+	}
+	if want := "guest:" + sid.Value; body2 != want {
+		t.Errorf("expected reused OwnerRef %q, got %q", want, body2)
+	}
+}
+
+// TestOwnerRefAuthenticated verifies that an authenticated caller's OwnerRef is
+// "user:<id>" rather than a guest reference.
+func TestOwnerRefAuthenticated(t *testing.T) {
+	srv := newAuthTestServer(t)
+	user := createUser(t, srv.db, "owner@example.com", "owner-pass-123", authentication.RoleUser)
+
+	cookies := loginJSON(t, srv, "owner@example.com", "owner-pass-123")
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/owner-auth", nil)
+	req.Header.Set("Accept", "application/json")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+
+	resp, err := noRedirectClient().Do(req)
+	if err != nil {
+		t.Fatalf("owner-auth request failed: %v", err)
+	}
+	body := readBody(t, resp)
+	resp.Body.Close()
+
+	if !strings.HasPrefix(body, "user:") {
+		t.Fatalf("expected a user owner reference, got %q", body)
+	}
+	if want := "user:"; !strings.HasPrefix(body, want) || body == want {
+		t.Fatalf("expected user:<id>, got %q", body)
+	}
+	_ = user
+}
+
+// TestSecureToken sanity-checks SecureToken: URL-safe, non-empty, and unique
+// across calls.
+func TestSecureToken(t *testing.T) {
+	urlSafe := regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		tok := authentication.SecureToken()
+		if tok == "" {
+			t.Fatal("SecureToken returned empty string")
+		}
+		if !urlSafe.MatchString(tok) {
+			t.Fatalf("SecureToken produced a non-URL-safe token: %q", tok)
+		}
+		if seen[tok] {
+			t.Fatalf("SecureToken produced a duplicate token: %q", tok)
+		}
+		seen[tok] = true
+	}
+}

--- a/test/auth_session_test.go
+++ b/test/auth_session_test.go
@@ -1,8 +1,10 @@
 package test
 
 import (
+	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"regexp"
 	"strings"
 	"testing"
@@ -100,13 +102,44 @@ func TestOwnerRefAuthenticated(t *testing.T) {
 	body := readBody(t, resp)
 	resp.Body.Close()
 
-	if !strings.HasPrefix(body, "user:") {
-		t.Fatalf("expected a user owner reference, got %q", body)
+	if want := fmt.Sprintf("user:%d", user.ID); body != want {
+		t.Errorf("expected OwnerRef %q, got %q", want, body)
 	}
-	if want := "user:"; !strings.HasPrefix(body, want) || body == want {
-		t.Fatalf("expected user:<id>, got %q", body)
+
+	// The authenticated owner reference must not depend on a guest cookie.
+	if got := sidCookie(resp); got != nil {
+		t.Errorf("expected no sid cookie for an authenticated OwnerRef, got %q", got.Value)
 	}
-	_ = user
+}
+
+// TestSessionIDIdempotentWithinRequest verifies that resolving the owner more than
+// once in a single request (e.g. reading a hold, then writing an order) yields one
+// consistent guest id and sets exactly one "sid" cookie — not a second, conflicting
+// identity that would split ownership across the same request.
+func TestSessionIDIdempotentWithinRequest(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		first := authentication.OwnerRef(w, r)
+		second := authentication.SessionID(w, r)
+		_, _ = fmt.Fprintf(w, "%s|guest:%s", first, second)
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/cart", nil))
+
+	result := rec.Result()
+	defer result.Body.Close()
+
+	parts := strings.Split(readBody(t, result), "|")
+	if len(parts) != 2 {
+		t.Fatalf("unexpected handler output: %q", parts)
+	}
+	if parts[0] != parts[1] {
+		t.Errorf("owner reference changed within a single request: %q then %q", parts[0], parts[1])
+	}
+
+	if cookies := result.Header.Values("Set-Cookie"); len(cookies) != 1 {
+		t.Errorf("expected exactly 1 Set-Cookie header, got %d: %v", len(cookies), cookies)
+	}
 }
 
 // TestSecureToken sanity-checks SecureToken: URL-safe, non-empty, and unique

--- a/test/auth_startup_test.go
+++ b/test/auth_startup_test.go
@@ -1,0 +1,86 @@
+package test
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	authentication "github.com/erancihan/clair/internal/server/authentication"
+)
+
+// authStartupSubprocessEnv guards the subprocess re-execution below so the child
+// run returns immediately instead of recursing.
+const authStartupSubprocessEnv = "GO_AUTH_STARTUP_SUBPROCESS"
+
+// TestSessionKeyStartup verifies the fail-closed signing-key policy. The
+// authentication package resolves its cookie signing key at package
+// initialization time, so a production process without SESSION_KEY must crash on
+// startup (before it can serve requests). This is checked by re-executing the
+// test binary under controlled environments.
+func TestSessionKeyStartup(t *testing.T) {
+	if os.Getenv(authStartupSubprocessEnv) == "1" {
+		// Inner run: if the process got this far, package init did not panic.
+		return
+	}
+
+	// Build a clean base environment for the child, stripping the variables we
+	// want to control so a parent-set value can't leak in.
+	baseEnv := func() []string {
+		env := []string{authStartupSubprocessEnv + "=1"}
+		for _, e := range os.Environ() {
+			switch {
+			case strings.HasPrefix(e, "SESSION_KEY="),
+				strings.HasPrefix(e, "APP_ENV="),
+				strings.HasPrefix(e, authStartupSubprocessEnv+"="):
+				continue
+			}
+			env = append(env, e)
+		}
+		return env
+	}
+
+	run := func(extra ...string) (string, error) {
+		cmd := exec.Command(os.Args[0], "-test.run", "TestSessionKeyStartup")
+		cmd.Env = append(baseEnv(), extra...)
+		out, err := cmd.CombinedOutput()
+		return string(out), err
+	}
+
+	t.Run("production without SESSION_KEY panics on startup", func(t *testing.T) {
+		out, err := run("APP_ENV=production") // SESSION_KEY intentionally absent
+		if err == nil {
+			t.Fatalf("expected the process to fail closed (non-zero exit), got success:\n%s", out)
+		}
+		if !strings.Contains(out, "SESSION_KEY") {
+			t.Fatalf("expected a panic mentioning SESSION_KEY, got:\n%s", out)
+		}
+	})
+
+	t.Run("production with SESSION_KEY starts", func(t *testing.T) {
+		out, err := run("APP_ENV=production", "SESSION_KEY=a-strong-production-signing-key")
+		if err != nil {
+			t.Fatalf("expected a clean start with SESSION_KEY set, got %v:\n%s", err, out)
+		}
+	})
+
+	t.Run("development without SESSION_KEY starts via dev fallback", func(t *testing.T) {
+		out, err := run("APP_ENV=development") // dev fallback key
+		if err != nil {
+			t.Fatalf("expected a clean start in development, got %v:\n%s", err, out)
+		}
+	})
+}
+
+// TestSecureCookies verifies SecureCookies tracks the production environment.
+func TestSecureCookies(t *testing.T) {
+	t.Setenv("APP_ENV", "production")
+	if !authentication.SecureCookies() {
+		t.Error("expected SecureCookies() to be true in production")
+	}
+
+	t.Setenv("APP_ENV", "development")
+	if authentication.SecureCookies() {
+		t.Error("expected SecureCookies() to be false outside production")
+	}
+}

--- a/test/auth_webhook_test.go
+++ b/test/auth_webhook_test.go
@@ -1,0 +1,95 @@
+package test
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	authentication "github.com/erancihan/clair/internal/server/authentication"
+)
+
+func sign(secret, body []byte) string {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write(body)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestVerifyProviderSignature(t *testing.T) {
+	secret := []byte("provider-shared-secret")
+	body := []byte(`{"event":"payment.succeeded","id":"evt_123"}`)
+	valid := sign(secret, body)
+
+	tests := []struct {
+		name   string
+		secret []byte
+		body   []byte
+		header string
+		want   bool
+	}{
+		{
+			name:   "valid bare hex signature is accepted",
+			secret: secret,
+			body:   body,
+			header: valid,
+			want:   true,
+		},
+		{
+			name:   "valid sha256-prefixed signature is accepted",
+			secret: secret,
+			body:   body,
+			header: "sha256=" + valid,
+			want:   true,
+		},
+		{
+			name:   "tampered body is rejected",
+			secret: secret,
+			body:   append([]byte("x"), body...),
+			header: valid,
+			want:   false,
+		},
+		{
+			name:   "tampered signature is rejected",
+			secret: secret,
+			body:   body,
+			header: valid[:len(valid)-1] + "0",
+			want:   false,
+		},
+		{
+			name:   "wrong secret is rejected",
+			secret: []byte("not-the-secret"),
+			body:   body,
+			header: valid,
+			want:   false,
+		},
+		{
+			name:   "empty signature header is rejected",
+			secret: secret,
+			body:   body,
+			header: "",
+			want:   false,
+		},
+		{
+			name:   "non-hex signature is rejected",
+			secret: secret,
+			body:   body,
+			header: "not-hex-!!",
+			want:   false,
+		},
+		{
+			name:   "empty secret is rejected",
+			secret: nil,
+			body:   body,
+			header: valid,
+			want:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := authentication.VerifyProviderSignature(tc.secret, tc.body, tc.header); got != tc.want {
+				t.Errorf("VerifyProviderSignature = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -42,6 +42,10 @@ func TestAuthentication(t *testing.T) {
 	// 1. Unauthenticated Access Step
 	t.Run("Fail to access protected route without token", func(t *testing.T) {
 		protectedReq, _ := http.NewRequest(http.MethodGet, baseURL+"/api/protected", nil)
+		// /api/protected is a JSON API route; identify as a JSON caller so the
+		// content-negotiated auth failure returns 401 rather than redirecting a
+		// browser to the login page.
+		protectedReq.Header.Set("Accept", "application/json")
 		resp, err := client.Do(protectedReq)
 		if err != nil {
 			t.Fatalf("Failed to make request: %v", err)

--- a/test/users_endpoint_test.go
+++ b/test/users_endpoint_test.go
@@ -1,0 +1,146 @@
+package test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/erancihan/clair/internal/database/models"
+	authentication "github.com/erancihan/clair/internal/server/authentication"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// bcryptHashPattern matches a bcrypt hash, so a test can assert that no response
+// body carries one regardless of the field name it might be nested under.
+var bcryptHashPattern = regexp.MustCompile(`\$2[aby]?\$\d{2}\$`)
+
+// openTestDB connects to the test database without resetting it, for tests that
+// need to inspect or adjust rows while a server is running.
+func openTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		dsn = defaultTestDatabaseURL
+	}
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect to test database: %v", err)
+	}
+	return db
+}
+
+// TestUsersEndpointRequiresAdminAndHidesPasswords exercises the real wired route
+// through the full server. Listing accounts is an administrative capability, and
+// no response may ever carry a password hash.
+func TestUsersEndpointRequiresAdminAndHidesPasswords(t *testing.T) {
+	baseURL, teardown := setupTestServer(t, "5054")
+	defer teardown()
+
+	client := &http.Client{
+		Timeout:       5 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+
+	const email = "listing@example.com"
+	const password = "listing-pass-123"
+
+	if err := postJSON(client, baseURL+"/api/v1/auth/register", map[string]string{
+		"username": "listing",
+		"email":    email,
+		"password": password,
+	}); err != nil {
+		t.Fatalf("registration failed: %v", err)
+	}
+
+	get := func(t *testing.T, cookies []*http.Cookie) *http.Response {
+		t.Helper()
+		req, _ := http.NewRequest(http.MethodGet, baseURL+"/api/v1/users/", nil)
+		req.Header.Set("Accept", "application/json")
+		for _, c := range cookies {
+			req.AddCookie(c)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("users request failed: %v", err)
+		}
+		return resp
+	}
+
+	t.Run("unauthenticated JSON caller is rejected", func(t *testing.T) {
+		resp := get(t, nil)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("expected 401 for an unauthenticated caller, got %d", resp.StatusCode)
+		}
+
+		body, _ := io.ReadAll(resp.Body)
+		if bcryptHashPattern.Match(body) {
+			t.Errorf("rejection response leaked a password hash: %s", body)
+		}
+	})
+
+	// Log in as the freshly registered account, which defaults to the user role.
+	loginBody, _ := json.Marshal(map[string]string{"email": email, "password": password})
+	loginResp, err := client.Post(baseURL+"/api/v1/auth/login", "application/json", strings.NewReader(string(loginBody)))
+	if err != nil {
+		t.Fatalf("login failed: %v", err)
+	}
+	loginResp.Body.Close()
+	if loginResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected login 200, got %d", loginResp.StatusCode)
+	}
+	cookies := loginResp.Cookies()
+
+	t.Run("regular user is forbidden", func(t *testing.T) {
+		resp := get(t, cookies)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("expected 403 for a non-admin, got %d", resp.StatusCode)
+		}
+	})
+
+	// Promote the account. AuthMiddleware re-reads the row on every request, so the
+	// existing session immediately reflects the new role.
+	db := openTestDB(t)
+	if err := db.Model(&models.User{}).Where("email = ?", email).
+		Update("role", authentication.RoleAdmin).Error; err != nil {
+		t.Fatalf("failed to promote user to admin: %v", err)
+	}
+
+	t.Run("admin gets the listing without any password", func(t *testing.T) {
+		resp := get(t, cookies)
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200 for an admin, got %d", resp.StatusCode)
+		}
+
+		body, _ := io.ReadAll(resp.Body)
+		payload := string(body)
+
+		if bcryptHashPattern.MatchString(payload) {
+			t.Errorf("users listing leaked a password hash: %s", payload)
+		}
+		if strings.Contains(strings.ToLower(payload), "password") {
+			t.Errorf("users listing still carries a password field: %s", payload)
+		}
+
+		// The listing must still be useful.
+		if !strings.Contains(payload, email) {
+			t.Errorf("expected the listing to include %q, got: %s", email, payload)
+		}
+		if !strings.Contains(payload, authentication.RoleAdmin) {
+			t.Errorf("expected the listing to include the role, got: %s", payload)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Builds the central, shared authentication / identity / session / security layer in `internal/server/authentication` that a shop CMS, a booking domain, and future admin surfaces can all consume. This is infrastructure only — no shop/booking domain logic, no new route groups, no external dependencies (all stdlib plus the existing `gorilla/sessions`, `bcrypt`, GORM).

### What's in the layer

**Identity + roles**
- `models.User` gains a `Role` column (`gorm:"index;default:user"`) — every account carries a coarse authorization level.
- `roles.go`: generic `RoleUser` / `RoleAdmin` string constants (open type → headroom for more roles later).
- `identity.go`: unexported context key, `Identity{UserID, Role}`, and `CurrentUser(ctx) (Identity, bool)`.
- `AuthMiddleware` re-validates the user row and **injects the `Identity`** into the request context.

**Session hardening**
- `constant.go` sources the cookie signing key from `SESSION_KEY` and **fails closed** in production (`panic` when unset), with a dev fallback otherwise. Adds `SecureCookies()` (true in prod).
- The cookie store carries **hardened defaults** (`HttpOnly`, `SameSite=Lax`, `Secure` only in production) rather than gorilla's, and the signature lifetime is pinned to the cookie lifetime. Login, logout, and CSRF all write cookies through one `sessionCookieOptions()` helper.

**Guest identity**
- `session.go`: `SessionID(w,r)` mints/reads a long-lived HttpOnly `sid` cookie (`Path=/`, SameSite=Lax) and is **idempotent within a request**; `OwnerRef(w,r)` returns `user:<id>` when authenticated else `guest:<sid>`; `SecureToken()` returns a 256-bit URL-safe token from `crypto/rand`. The on-disk `user:<id>` / `guest:<sid>` format is what downstream domains will persist.

**Authorization UX**
- `AdminMiddleware` wraps `AuthMiddleware` and returns 403 for non-admins.
- Auth failures are content-negotiated by `unauthorized(w,r)`: **401** for JSON callers (`Accept`/`Content-Type: application/json`), else **302** to `/login?next=<escaped path>`.

**Login return path**
- `LoginPage` renders a validated `next` into a hidden field; `AuthLogin` redirects browser (form) logins to a `safeNext`-validated path (same-origin, leading-slash; rejects `//host`, backslash tricks, and absolute URLs) instead of a hard-coded `/dashboard`. Logout still ends only the auth session, keeping the `sid` cookie.

**CSRF** — `csrf.go`: `CSRFToken(r)` (read-or-create a session-bound token) and `CSRF()` middleware verifying `X-CSRF-Token` / `csrf_token` on POST/PUT/PATCH/DELETE with a constant-time compare (`crypto/subtle`), 403 on mismatch; safe methods pass through. The token **rotates on login**. Delivered ready to mount — **not** wired globally; login/register stay exempt.

**Webhook signature verify** — `webhook.go`: `VerifyProviderSignature(secret, body, sigHeader)` — HMAC-SHA256 over the raw body, constant-time compare (`hmac.Equal`), accepts a bare hex digest or `sha256=`-prefixed value. Verifier only; the handler that consumes it belongs to the booking domain.

**Config** — `.env.example` documents `SESSION_KEY` and `APP_ENV`.

## Defects found in self-review

Five issues were found by reviewing the layer after it was written. Each was reproduced with a failing test first, then fixed.

1. **`SessionID` was not idempotent within a request.** The minted id was only written to the response, so a second call in the same request (e.g. resolving the owner to read a hold, then again to write an order) minted a *different* id and emitted a second `Set-Cookie` — one request could produce two conflicting guest owner references, breaking exactly the attribution `OwnerRef` exists for. The id is now mirrored onto the request.

2. **The store kept gorilla's defaults** — `HttpOnly` unset, `SameSite=None`, `Secure` hard-coded true. `AuthLogout` does not override options, so it wrote its deletion cookie **without `HttpOnly`** and **with `Secure` even outside production**, where browsers drop it over plain HTTP — leaving the session cookie in place after logout. Defaults are now hardened and logout sets the attributes explicitly, resolved per request rather than at package init.

3. **Password hashes were publicly readable.** `models.User` is encoded straight to JSON and `GET /api/v1/users` was unauthenticated, so every account's bcrypt hash was exposed; adding `Role` had widened that same response. The field is now `json:"-"`, so no handler can serialize it.

4. **The CSRF token survived the login boundary.** `store.Get` returns the existing session, so a token minted before signing in carried into the authenticated session — anyone who had planted or observed the visitor's pre-login cookie would hold a valid token for their authenticated session. Login now rotates it across the privilege change.

5. **The user listing was world-readable.** Beyond the hashes, `GET /api/v1/users` exposed every account's username, email, and role to anonymous callers. The group now runs behind `AdminMiddleware`, and the query `Omit`s the password column so the hash is not even read out of the database for a listing that never needs it.

Also verified as **not** vulnerable: templ escapes the rendered `next` value (an attribute-breaking payload comes back as `&#34;`), net/http neutralizes CRLF in the redirect `Location`, and `RegisterPayload` has no `Role` field (nothing decodes JSON into `models.User`), so a user cannot self-assign admin.

## Credentials can no longer be returned by any endpoint

Three independent layers, verified by audit and test:
- `Password` is `json:"-"` — no handler can serialize it, however the struct is used.
- An audit of every response writer (`json.NewEncoder`/`json.Marshal`/`w.Write`) confirms the users listing is the **only** place a `User` is ever encoded, and nothing caches users as JSON.
- That listing additionally `Omit`s the column, so the hash never leaves the database. Confirmed SQL: `SELECT id, created_at, updated_at, deleted_at, username, email, role FROM users`.

The regression test matches on **bcrypt hash shape** (`$2a$…`) rather than a field name, so a future field cannot quietly reintroduce the leak.

## Preserved `/api/v1/auth/*` contract

- `POST /login` with `Content-Type: application/json` still returns a bare **200** and sets the session cookie. Browser form submissions are an additive path that redirects. (JSON detection is now a substring match, so `application/json; charset=utf-8` also gets the documented JSON behavior instead of a redirect.)
- `POST /register` still returns **201** (**409** on duplicate); new users default to role `user` via the DB default.
- `GET /logout` unchanged apart from the cookie-attribute fix above.

**Changed outside `auth/*` (deliberate, see defects 3 and 5):** `GET /api/v1/users` now requires an admin session and no longer includes the `password` field. Remaining fields are unchanged.

The only existing-test change: the `/api/protected` unauthenticated check now sends `Accept: application/json` so the content-negotiated failure stays a 401 (that route is a JSON API endpoint).

## Public API (stable — imported by both domains)

`CurrentUser`, `AdminMiddleware`, `SessionID`, `OwnerRef`, `CSRF`, `CSRFToken`, `SecureToken`, `VerifyProviderSignature`, `RoleUser`/`RoleAdmin` (plus `AuthMiddleware`, `SecureCookies`, `CSRFHeaderName`/`CSRFFieldName`).

**Integration note:** `OwnerRef` reports `user:<id>` only when `AuthMiddleware` has injected an `Identity`. On a route *not* behind it, a signed-in visitor is indistinguishable from a guest and gets `guest:<sid>`. Any route whose ownership must follow the account needs to run behind `AuthMiddleware` (or a future optional-auth middleware, if public pages end up needing account-aware ownership).

## Verification

All commands run against PostgreSQL 16.

```
go build ./...             # ✓ exit 0
go vet ./...               # ✓ exit 0
gofmt -l internal/ test/   # ✓ no output
make build                 # ✓ assets + templ generate + binary
make test                  # ✓ ok  github.com/erancihan/clair/test  (64 PASS subtests, 0 failures)
go test -race ./test/...   # ✓ ok  no data races
```

Test coverage (table-driven, Postgres + `httptest`):
- login → `CurrentUser` returns the correct `Identity`; valid cookie but **deleted user → 401**.
- `AdminMiddleware`: admin → pass, role `user` → **403**, unauthenticated browser → **302 `/login?next=`**, unauthenticated JSON → **401**.
- `GET /api/v1/users` through the **real wired server**: unauthenticated → 401, non-admin → 403, admin → 200 with no bcrypt-shaped string anywhere in the body.
- Login: JSON contract preserved (200); form login redirects to a validated `next`; `safeNext` rejects hostile targets; login page renders the `next` field.
- Guest `sid` cookie minted once (HttpOnly, `Path=/`) and reused; `OwnerRef` returns `user:<id>` / `guest:<sid>`; guest id stable and single-cookie within one request.
- Cookie attributes for the session and `sid` cookies across development and production.
- CSRF: tokenless mutating request → **403**; matching header/form token → **pass**; GET → **pass**; token rotates across login.
- `models.User` never serializes a password hash.
- `VerifyProviderSignature`: valid HMAC accepted; tampered body/signature, wrong/empty secret, non-hex rejected.
- Fail-closed startup: re-executes the test binary to assert a production process without `SESSION_KEY` **panics on init**, and boots cleanly otherwise.

Manual end-to-end against the built binary: register 201 / duplicate 409; JSON login 200 + cookie; wrong password 401; protected → 401 (JSON) / 302 (browser) / 200 (with cookie); form login `next=/account` → `/account`; hostile `next=//evil` → `/dashboard`; logout cookie carries `HttpOnly; SameSite=Lax` with no `Secure` in dev and the session is rejected afterwards; `/api/v1/users` returns 401 → 403 → 200 as the caller's role changes, with no hash in any response.

## Out of scope (intentionally)

No shop/booking models, routes, cart, checkout, or the payment webhook handler; `CSRF()` is not mounted globally and no domain route groups were invented. Everything stays in the single `internal/server/authentication` package to avoid an import cycle with future domains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6Qiq5M33tzDMtpEW9ENhD